### PR TITLE
Fix #25 - Caret is kept at the same position after evaluation

### DIFF
--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/ScriptEditor.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/ScriptEditor.scala
@@ -74,8 +74,9 @@ class ScriptEditor extends TextEditor with SelectionTracker with ISourceViewerEd
 
     override def caretOffset: Int = {
       var offset = -1
-      runInUi { //FIXME: Can I make this non-blocking!?
-        offset = getSourceViewer().getTextWidget().getCaretOffset()
+      SWTUtils.syncExec {
+        // Read the comment in `runInUi` 
+        if(!disposed) offset = getSourceViewer().getTextWidget().getCaretOffset()
       }
       offset
     }

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/text/Mixer.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/text/Mixer.scala
@@ -82,7 +82,7 @@ class Mixer {
       align()
       insert(sep: _*)
       insert(cs: _*)
-      if (written < caret) newcaret = caret + inserted
+      if (written < caret) newcaret = scala.math.min(caret + inserted, caret)
     }
     mixed ++= source.view(written, source.length)
     (mixed.toArray, newcaret)

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/text/SourceInserter.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/text/SourceInserter.scala
@@ -12,11 +12,14 @@ object SourceInserter {
     def leftPart(str: String) =
       (str split """//>|//\|""").head
     def isContinuation(str: String) =
-      ((str contains "//>") || (str contains "//|")) && (leftPart(str) forall Character.isWhitespace)
-    def stripTrailingWS(str: String) =
-      str take (str lastIndexWhere (!Character.isWhitespace(_))) + 1
+      ((str contains "//>") || (str contains "//|")) && isEmpty(leftPart(str))
+    def isEmpty(str: String) = str forall Character.isWhitespace
+    def stripTrailingWS(str: String) = str take (str lastIndexWhere (!Character.isWhitespace(_))) + 1
+    def stripTrailingWSIfNonEmpty(str: String) = 
+      if(isEmpty(str)) str 
+      else stripTrailingWS(str)
     val prefixes =
-      lines filterNot isContinuation map leftPart map stripTrailingWS
+      lines filterNot isContinuation map leftPart map stripTrailingWSIfNonEmpty
     (prefixes mkString "\n").toArray
   }
 }


### PR DESCRIPTION
- Empty lines are no longer stripped, the reasons are:
  - Maintains correct indentation of empty lines.
  - Correct handling of caret position (i.e., if the caret is
    in the middle of an empty line, it should stay there after
    evaluation).
- The new caret position can never be after the old caret position
  (this should motivate the change in Mixer.scala)

(let's test the PR validator)
