### PR TITLE
Major clean-up in POM's properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ There are 5 Eclipse plugins:
 
 * the plugin itself
 * the `plugin.tests` fragment
+* the plugin's runtime library (needed for producing the worksheet's output)
 * an Eclipse feature
 * an Eclipse source feature
 * an Eclipse update-site
@@ -18,14 +19,6 @@ based on Tycho, enabling command line builds.
 
 ## Note:
 
-There are several profiles for choosing what version
-of the Scala IDE and Scala compiler you want to build against:
-
-* `scala-ide-2.0-scala-2.9`
-* `scala-ide-2.0.x-scala-2.9`
-* `scala-ide-master-scala-2.9`
-* `scala-ide-master-scala-trunk`
-
-Run maven like this:
-
-    mvn -P scala-ide-master-scala-trunk clean install
+There are several profiles for choosing what version of the Scala IDE, Scala compiler and Eclipse 
+you want to build against. Read [here][https://github.com/scala-ide/scala-worksheet/wiki/Build-the-Worksheet] 
+for more details.

--- a/org.scalaide.worksheet/META-INF/MANIFEST.MF
+++ b/org.scalaide.worksheet/META-INF/MANIFEST.MF
@@ -24,7 +24,7 @@ Require-Bundle:
  org.scala-ide.scala.library,
  org.scala-ide.scala.compiler,
  org.scala-ide.sdt.core,
- scalariform;bundle-version="0.1.3",
+ scalariform,
  org.scala-ide.sbt.full.library,
  org.eclipse.core.filesystem,
  org.eclipse.ltk.core.refactoring,

--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,10 @@
   <properties>
     <encoding>UTF-8</encoding>
     <!-- p2 repositories location -->
-    <repo.eclipse.indigo>http://download.eclipse.org/releases/indigo/</repo.eclipse.indigo>
-    <repo.eclipse.juno>http://download.eclipse.org/releases/juno/</repo.eclipse.juno>
-    <repo.ajdt.indigo>http://download.eclipse.org/tools/ajdt/37/dev/update</repo.ajdt.indigo>
     <repo.scala-ide.root>http://download.scala-ide.org</repo.scala-ide.root>
-
+    
     <!-- fixed versions -->
-    <tycho.version>0.15.0</tycho.version>
+    <tycho.version>0.16.0</tycho.version>
     <scala.plugin.version>3.0.2</scala.plugin.version>
 
     <!-- tycho test related -->
@@ -39,109 +36,168 @@
     <tycho.test.jvmArgs>-Xmx800m -XX:MaxPermSize=256m -Dsdtcore.headless ${tycho.test.weaving} ${tycho.test.OSspecific}</tycho.test.jvmArgs>
 
     <!-- dependencies repos -->
-    <eclipse.codename>indigo</eclipse.codename>
-    <repo.eclipse>${repo.eclipse.indigo}</repo.eclipse>
-    <repo.ajdt>${repo.ajdt.indigo}</repo.ajdt>
+    <eclipse.codename>Specify a profile!</eclipse.codename>
+    <repo.eclipse>Specify a profile!</repo.eclipse>
+    <repo.ajdt>Specify a profile!</repo.ajdt>
+    <weaving.hook.plugin.version>Specify a profile!</weaving.hook.plugin.version>
 
     <!-- some default values, can be overwritten by profiles -->
-    <scala.version>specify a profile!</scala.version> <!-- version is different for each profile -->
-    <version.suffix>2_09</version.suffix>
-    <scala.version.short>2.9</scala.version.short>
+    <scala.version>Specify a profile!</scala.version>
     <version.tag>local</version.tag>
-    <repo.scala-ide>specify a profile!</repo.scala-ide> <!-- repository is different for each profile -->
+    <repo.scala-ide>Specify a profile!</repo.scala-ide> <!-- repository is different for each profile -->
+    
+    <!-- dependencies version number -->
     <junit.version>4.10</junit.version>
     <mockito.version>1.9.0</mockito.version>
    </properties>
 
   <profiles>
-    <!-- this is the default profile, using the stable builds-->
     <profile>
-      <!-- Milestone Scala IDE with Scala 2.9 -->
-      <id>scala-ide-milestone-scala-2.9</id>
+      <id>indigo</id>
       <properties>
-        <scala.version>2.9.3-scala-ide-m2</scala.version>
-        <repo.scala-ide>${repo.scala-ide.root}/sdk/e37/scala29/dev/staging/</repo.scala-ide>
+        <eclipse.codename>indigo</eclipse.codename>
+        <repo.eclipse>http://download.eclipse.org/releases/indigo/</repo.eclipse>
+        <repo.ajdt>http://download.eclipse.org/tools/ajdt/37/update</repo.ajdt>
+        <weaving.hook.plugin.version>1.0.200.I20120427-0800</weaving.hook.plugin.version>
       </properties>
-        <repositories>
-          <repository>
-            <!-- extra repository containing the tagged Scala 2.9.3-scala-ide-m2 release -->
-            <id>typesafe-ide</id>
-            <name>Typesafe IDE repository</name>
-            <url>http://repo.typesafe.com/typesafe/ide-2.9</url>
-            <snapshots><enabled>true</enabled></snapshots>
-          </repository>
-        </repositories>
     </profile>
     <profile>
-      <!-- Milestone Scala IDE with Scala 2.10 -->
-      <id>scala-ide-milestone-scala-2.10</id>
+      <id>juno</id>
       <properties>
-        <scala.version>2.10.0-SNAPSHOT</scala.version>
+        <eclipse.codename>juno</eclipse.codename>
+        <repo.eclipse>http://download.eclipse.org/releases/juno/</repo.eclipse>
+        <repo.ajdt>http://download.eclipse.org/tools/ajdt/42/update</repo.ajdt>
+        <weaving.hook.plugin.version>1.0.200.v20120524-1707</weaving.hook.plugin.version>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>2.9.x</id>
+      <properties>
+        <scala.version>2.9.3-RC1</scala.version>
+        <version.suffix>2_09</version.suffix>
+        <scala.version.short>2.9</scala.version.short>
+      </properties>
+      <repositories>
+        <repository>
+          <id>typesafe-ide</id>
+          <name>Typesafe IDE repository</name>
+          <url>http://repo.typesafe.com/typesafe/ide-2.9</url>
+          <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+      </repositories>
+    </profile>
+
+    <profile>
+      <id>2.10.x</id>
+      <properties>
+        <scala.version>2.10.0-RC5</scala.version>
         <version.suffix>2_10</version.suffix>
         <scala.version.short>2.10</scala.version.short>
-        <repo.scala-ide>${repo.scala-ide.root}/sdk/e37/scala210/dev/staging/</repo.scala-ide>
+      </properties>
+      <repositories>
+        <repository>
+          <id>typesafe-ide</id>
+          <name>Typesafe IDE repository</name>
+          <url>http://repo.typesafe.com/typesafe/ide-2.10</url>
+          <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+      </repositories>
+    </profile>
+
+    <profile>
+      <id>2.11.x</id>
+      <properties>
+        <scala.version>2.11.0-SNAPSHOT</scala.version>
+        <version.suffix>2_11</version.suffix>
+        <scala.version.short>2.11</scala.version.short>
+      </properties>
+      <repositories>
+        <repository>
+          <id>typesafe-ide</id>
+          <name>Typesafe IDE repository</name>
+          <url>http://repo.typesafe.com/typesafe/ide-2.11</url>
+          <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+      </repositories>
+    </profile>
+
+    <profile>
+      <id>next-dev-scala-ide-indigo-scala-2.9</id>
+      <properties>
+        <repo.scala-ide>${repo.scala-ide.root}/sdk/next/e37/scala29/dev/base/</repo.scala-ide>
       </properties>
     </profile>
     <profile>
-      <!-- Milestone Scala IDE for Eclipse Juno with Scala 2.9 -->
-      <id>scala-ide-juno-milestone-scala-2.9</id>
+      <id>next-dev-scala-ide-indigo-scala-2.10</id>
       <properties>
-        <scala.version>2.9.3-scala-ide-m2</scala.version>
-        <repo.scala-ide>${repo.scala-ide.root}/sdk/e38/scala29/dev/staging/</repo.scala-ide>
+        <repo.scala-ide>${repo.scala-ide.root}/sdk/next/e37/scala210/dev/base/</repo.scala-ide>
       </properties>
-        <repositories>
-          <repository>
-            <!-- extra repository containing the tagged Scala 2.9.3-scala-ide-m2 release -->
-            <id>typesafe-ide</id>
-            <name>Typesafe IDE repository</name>
-            <url>http://repo.typesafe.com/typesafe/ide-2.9</url>
-            <snapshots><enabled>true</enabled></snapshots>
-          </repository>
-        </repositories>
     </profile>
     <profile>
-      <!-- Milestone Scala IDE for Eclipse Juno with Scala 2.10 -->
-      <id>scala-ide-juno-milestone-scala-2.10</id>
+      <id>next-dev-scala-ide-juno-scala-2.9</id>
       <properties>
-        <scala.version>2.10.0-SNAPSHOT</scala.version>
-        <version.suffix>2_10</version.suffix>
-        <scala.version.short>2.10</scala.version.short>
-        <repo.scala-ide>${repo.scala-ide.root}/sdk/e38/scala210/dev/staging/</repo.scala-ide>
+        <repo.scala-ide>${repo.scala-ide.root}/sdk/next/e38/scala29/dev/base/</repo.scala-ide>
       </properties>
     </profile>
+    <profile>
+      <id>next-dev-scala-ide-juno-scala-2.10</id>
+      <properties>
+        <repo.scala-ide>${repo.scala-ide.root}/sdk/next/e38/scala210/dev/base/</repo.scala-ide>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>dev-scala-ide-indigo-scala-2.9</id>
+      <properties>
+        <repo.scala-ide>${repo.scala-ide.root}/sdk/e37/scala29/dev/site/</repo.scala-ide>
+      </properties>
+    </profile>
+    <profile>
+      <id>dev-scala-ide-indigo-scala-2.10</id>
+      <properties>
+        <repo.scala-ide>${repo.scala-ide.root}/sdk/e37/scala210/dev/site/</repo.scala-ide>
+      </properties>
+    </profile>
+    <profile>
+      <id>dev-scala-ide-juno-scala-2.9</id>
+      <properties>
+        <repo.scala-ide>${repo.scala-ide.root}/sdk/e38/scala29/dev/site/</repo.scala-ide>
+      </properties>
+    </profile>
+    <profile>
+      <id>dev-scala-ide-juno-scala-2.10</id>
+      <properties>
+        <repo.scala-ide>${repo.scala-ide.root}/sdk/e38/scala210/dev/site/</repo.scala-ide>
+      </properties>
+    </profile>
+    
     <profile>
       <!-- nightly Scala IDE with Scala 2.9 -->
-      <id>scala-ide-master-scala-2.9</id>
+      <id>nightly-scala-ide-scala-2.9</id>
       <properties>
         <repo.scala-ide>${repo.scala-ide.root}/nightly-update-master-29x</repo.scala-ide>
         <scala.version>2.9.3-SNAPSHOT</scala.version>
       </properties>
     </profile>
     <profile>
-      <!-- nightly Scala IDE with Scala trunk -->
-      <id>scala-ide-master-scala-trunk</id>
+      <!-- nightly Scala IDE with Scala 2.10.0 -->
+      <id>nightly-scala-ide-scala-2.10.0</id>
       <properties>
-        <scala.version>2.10.0-SNAPSHOT</scala.version>
-        <version.suffix>2_10</version.suffix>
-        <scala.version.short>2.10</scala.version.short>
-        <repo.scala-ide>${repo.scala-ide.root}/nightly-update-master-trunk</repo.scala-ide>
+        <repo.scala-ide>${repo.scala-ide.root}/nightly-update-master-2.10.0</repo.scala-ide>
       </properties>
     </profile>
     <profile>
       <!-- nightly Scala IDE for Eclipse Juno with Scala 2.9 -->
-      <id>scala-ide-juno-master-scala-2.9</id>
+      <id>nightly-scala-ide-juno-scala-2.9</id>
       <properties>
         <repo.scala-ide>${repo.scala-ide.root}/nightly-update-juno-master-29x</repo.scala-ide>
-        <scala.version>2.9.3-SNAPSHOT</scala.version>
       </properties>
     </profile>
     <profile>
-      <!-- nightly Scala IDE for Eclipse Juno with Scala trunk -->
-      <id>scala-ide-juno-master-scala-trunk</id>
+      <!-- nightly Scala IDE for Eclipse Juno with Scala 2.10.0 -->
+      <id>nightly-scala-ide-juno-master-scala-trunk</id>
       <properties>
-        <scala.version>2.10.0-SNAPSHOT</scala.version>
-        <version.suffix>2_10</version.suffix>
-        <scala.version.short>2.10</scala.version.short>
         <repo.scala-ide>${repo.scala-ide.root}/nightly-update-juno-master-2.10.x</repo.scala-ide>
       </properties>
     </profile>
@@ -253,8 +309,8 @@
 
   <!-- scm configuration is require to extract the github hash-->
   <scm> 
-    <connection>scm:git://github.com/skyluc/plugin.git</connection> 
-    <url>https://github.com/skyluc/plugin</url> 
+    <connection>scm:git://github.com/scala-ide/scala-worksheet.git</connection> 
+    <url>https://github.com/scala-ide/scala-worksheet</url> 
   </scm>
 
   <dependencyManagement>
@@ -332,7 +388,7 @@
               <frameworkExtension>
                 <groupId>p2.osgi.bundle</groupId>
                 <artifactId>org.eclipse.equinox.weaving.hook</artifactId>
-                <version>1.0.200.I20120427-0800</version>
+                <version>${weaving.hook.plugin.version}</version>
               </frameworkExtension>
             </frameworkExtensions>
             <bundleStartLevel>


### PR DESCRIPTION
This clean-up was motivated by the impossibility of building the worksheet
against the freshly staged 2.1-M3 for Juno. In short, the wrong `eclipse.repo` and
`ajdt.repo` where provided when building the worksheet for Juno.

With the intent of making the POM easier to understand, I've created a number of new
profiles that should simplify the task of building a release across different Scala
and Eclipse versions.

Last, I took the opportunity to also move to the latest released Tycho, i.e., 0.16.

I'll make sure to update the wiki to reflect the changes.

(I'll have to bakport this to 0.1.x, prior to release 0.1.3)
