### PR TITLE
Set file encoding to `UTF-8` for tests execution in Tycho

### DIFF
--- a/org.scalaide.worksheet.tests/src/org/scalaide/worksheet/runtime/WorksheetEvalTest.scala
+++ b/org.scalaide.worksheet.tests/src/org/scalaide/worksheet/runtime/WorksheetEvalTest.scala
@@ -301,20 +301,18 @@ object a {
 """
     runTest("eval-test/wrongInstrumentationForLoops.sc", initial, expected)
   }
-  
-  @Ignore("Unfortunately this tests fails on MacOSX when executed from the command line, while it works fine when executed inside Eclipse. " + 
-          "This test was created while working on a fix for the encoding issue reported in #124. We'll keep the mentioned ticket opened until this test is fixed")
+
   @Test
   def unicodeCharactersAreAllowed() {
     val initial = """
 object Snowman {
-  def ☃ = "yes, this is a snowman"
+  def ☃ : AnyRef = "yes, this is a snowman"
   println("%s".format(☃))
 }
 """
     val expected = """
 object Snowman {
-  def ☃ = "yes, this is a snowman"                //> ☃ : => java.lang.String
+  def ☃ : AnyRef = "yes, this is a snowman"       //> ☃ : => AnyRef
   println("%s".format(☃))                         //> yes, this is a snowman
 }
 """

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,11 @@
   <name>Scala Worksheet</name>
   <packaging>pom</packaging>
 
+  <properties>
+    <tycho.test.encoding>-Dfile.encoding=UTF-8</tycho.test.encoding>
+    <tycho.test.jvmArgs>-Xmx800m -XX:MaxPermSize=256m -Dsdtcore.headless ${tycho.test.encoding} ${tycho.test.weaving} ${tycho.test.OSspecific}</tycho.test.jvmArgs>
+  </properties>
+
   <modules>
     <module>org.scalaide.worksheet.runtime.library</module>
     <module>org.scalaide.worksheet</module>


### PR DESCRIPTION
- Had to change the return type of the Snowman to `AnyRef` for
  the test to pass against both Scala 2.9 and Scala 2.10 (the
  returned name for the `String` type is different in 2.9 and
  2.10)
- Pass `-Dfile.encoding=UTF-8` to Tycho test task.
- Re-enabled encoding test.

Fix #124
