### PR TITLE
Renames LexicalStructure to LexStructure

### DIFF
--- a/org.scalaide.worksheet/src/scala/tools/nsc/interactive/ProgramInstrumenter.scala
+++ b/org.scalaide.worksheet/src/scala/tools/nsc/interactive/ProgramInstrumenter.scala
@@ -30,7 +30,7 @@ final class ProgramInstrumenter(compiler: ScalaPresentationCompiler) extends Has
     private def instrumentation(source: SourceFile, line: Int): (String, Array[Char]) = {
       val tree = global.typedTree(source, forceReload = true)
       val endOffset = if (line < 0) source.length else source.lineToOffset(line + 1)
-      val patcher = new Patcher(source.content, new LexicalStructure(source), endOffset)
+      val patcher = new Patcher(source.content, new LexStructure(source), endOffset)
       patcher.traverse(tree)
       (patcher.objectName, patcher.result)
     }

--- a/org.scalaide.worksheet/src/scala/tools/nsc/interactive/ScratchPadMaker2.scala
+++ b/org.scalaide.worksheet/src/scala/tools/nsc/interactive/ScratchPadMaker2.scala
@@ -17,7 +17,7 @@ private[interactive] trait ScratchPadMaker2 {
 
   private case class Patch(offset: Int, text: String)
 
-  protected class Patcher(contents: Array[Char], lex: LexicalStructure, endOffset: Int) extends Traverser {
+  protected class Patcher(contents: Array[Char], lex: LexStructure, endOffset: Int) extends Traverser {
     var objectName: String = ""
 
     private val patches = new ArrayBuffer[Patch]
@@ -158,7 +158,7 @@ private[interactive] trait ScratchPadMaker2 {
     }
   }
 
-  class LexicalStructure(source: SourceFile) {
+  class LexStructure(source: SourceFile) {
     val token = new ArrayBuffer[Int]
     val startOffset = new ArrayBuffer[Int]
     val endOffset = new ArrayBuffer[Int]


### PR DESCRIPTION
The old name was creating ambiguous error with global._

I'm merging directly this change. I need it to compile on Scala 2.11.0-M3.

But feel free to comment.
