### PR TITLE
Unified handling of VM arguments and document's encoding

### DIFF
--- a/org.scalaide.worksheet.tests/src/org/scalaide/worksheet/testutil/EvalTester.scala
+++ b/org.scalaide.worksheet.tests/src/org/scalaide/worksheet/testutil/EvalTester.scala
@@ -2,7 +2,6 @@ package org.scalaide.worksheet.testutil
 
 import org.scalaide.worksheet.editor.DocumentHolder
 import org.scalaide.worksheet.runtime._
-import org.scalaide.worksheet.editor.DocumentHandler
 
 object EvalTester {
   import WorksheetUtils._
@@ -16,8 +15,6 @@ object EvalTester {
     override def beginUpdate() { done = false }
     
     override def getContents = doc
-
-    override def encoding = DocumentHandler.DefaultEncoding
 
     override def replaceWith(newDoc: String, revealOffset: Int) {
       doc = newDoc

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/WorksheetPlugin.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/WorksheetPlugin.scala
@@ -9,6 +9,8 @@ import scala.tools.eclipse.util.Utils
 import org.eclipse.core.runtime.IPath
 import scala.tools.eclipse.logging.HasLogger
 import org.eclipse.core.runtime.Path
+import org.scalaide.worksheet.properties.WorksheetPreferences
+import org.eclipse.core.resources.IProject
 
 object WorksheetPlugin extends HasLogger {
   @volatile var plugin: WorksheetPlugin = _

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/DocumentHolder.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/DocumentHolder.scala
@@ -1,7 +1,5 @@
 package org.scalaide.worksheet.editor
 
-import java.nio.charset.Charset
-
 /** A document holder, such as the ScriptEditor.
  * 
  *  Implementers receive asynchronous updates through `replaceWith`, therefore
@@ -15,9 +13,6 @@ trait DocumentHolder {
   
   /** Return the contents of the document. */
   def getContents: String
-
-  /** Return the encoding used for `this` document. */
-  def encoding: Charset
   
   /** Replace the contents with the new text, and optionally reveal the given offset in
    *  the UI, if there is one. This method call is guaranteed to come after `beginUpdate`
@@ -33,8 +28,4 @@ trait DocumentHolder {
    *  to allow the user to interrupt the evaluation.
    */
   def endUpdate(): Unit
-}
-
-object DocumentHandler {
-  final val DefaultEncoding: Charset = Charset.forName("UTF-8")
 }

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/ScriptEditor.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/ScriptEditor.scala
@@ -1,15 +1,23 @@
 package org.scalaide.worksheet.editor
 
 import scala.tools.eclipse.ISourceViewerEditor
+import scala.tools.eclipse.InteractiveCompilationUnit
 import scala.tools.eclipse.logging.HasLogger
+import scala.tools.eclipse.ui.InteractiveCompilationUnitEditor
+import scala.tools.eclipse.util.SWTUtils
+import org.eclipse.jdt.core.compiler.IProblem
+import org.eclipse.jdt.internal.ui.javaeditor.CompilationUnitDocumentProvider.ProblemAnnotation
 import org.eclipse.jface.action.IMenuManager
 import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.ITextSelection
+import org.eclipse.jface.text.Position
 import org.eclipse.jface.text.source.Annotation
 import org.eclipse.jface.text.source.IAnnotationModel
+import org.eclipse.jface.text.source.IAnnotationModelExtension
 import org.eclipse.jface.text.source.IAnnotationModelExtension2
 import org.eclipse.jface.text.source.ISourceViewer
 import org.eclipse.jface.util.PropertyChangeEvent
+import org.eclipse.swt.SWT
 import org.eclipse.swt.events.KeyAdapter
 import org.eclipse.swt.events.KeyEvent
 import org.eclipse.ui.editors.text.TextEditor
@@ -18,18 +26,6 @@ import org.eclipse.ui.texteditor.TextOperationAction
 import org.scalaide.worksheet.ScriptCompilationUnit
 import org.scalaide.worksheet.WorksheetPlugin
 import org.scalaide.worksheet.editor.action.RunEvaluationAction
-import org.eclipse.swt.SWT
-import scala.tools.eclipse.InteractiveCompilationUnit
-import scala.tools.eclipse.ui.InteractiveCompilationUnitEditor
-import org.eclipse.jdt.core.compiler.IProblem
-import org.eclipse.jdt.internal.ui.javaeditor.CompilationUnitDocumentProvider.ProblemAnnotation
-import org.eclipse.jface.text.Position
-import scala.collection.JavaConverters
-import org.eclipse.jface.text.source.IAnnotationModelExtension
-import scala.tools.eclipse.util.SWTUtils
-import java.nio.charset.Charset
-import java.nio.charset.UnsupportedCharsetException
-import java.nio.charset.IllegalCharsetNameException
 
 object ScriptEditor {
 
@@ -75,16 +71,6 @@ class ScriptEditor extends TextEditor with SelectionTracker with ISourceViewerEd
     private def doc: IDocument = getDocumentProvider.getDocument(getEditorInput)
 
     override def getContents: String = doc.get
-
-    override def encoding: Charset = {
-      val projectEncoding = getInteractiveCompilationUnit.scalaProject.underlying.getDefaultCharset()
-      try Charset.forName(projectEncoding)
-      catch {
-        case _: IllegalCharsetNameException | _: IllegalArgumentException | _: UnsupportedCharsetException => 
-          eclipseLog.error("Unrecognized project's encoding '%s'. Using '%s'.".format(projectEncoding, DocumentHandler.DefaultEncoding))
-          DocumentHandler.DefaultEncoding
-      }
-    }
 
     override def replaceWith(content: String, revealPos: Int): Unit = {
       // we need to turn off evaluation on save if we don't want to loop forever 
@@ -260,7 +246,7 @@ class ScriptEditor extends TextEditor with SelectionTracker with ISourceViewerEd
     }
 
     val newMap = newAnnotations.toMap
-    import JavaConverters._
+    import scala.collection.JavaConverters._
     annotationModel.replaceAnnotations(previousAnnotations.toArray, newMap.asJava)
     previousAnnotations = newAnnotations.map(_._1)
 

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/Configuration.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/Configuration.scala
@@ -1,12 +1,17 @@
 package org.scalaide.worksheet.runtime
 
 import java.io.File
-import java.io.{FileOutputStream, OutputStreamWriter}
+import java.io.FileOutputStream
+import java.io.OutputStreamWriter
+import java.nio.charset.Charset
+
 import scala.tools.eclipse.ScalaProject
+
 import org.eclipse.core.resources.IProject
 import org.eclipse.core.runtime.IPath
 import org.eclipse.core.runtime.Path
-import java.nio.charset.Charset
+import org.scalaide.worksheet.WorksheetPlugin
+import org.scalaide.worksheet.properties.WorksheetPreferences
 
 private[runtime] object Configuration {
   private val RootFolder = new Path(".worksheet")
@@ -75,4 +80,7 @@ final private[runtime] class Configuration private (project: IProject) {
 
     source
   }
+
+  def vmArgs: VmArguments =
+    new VmArguments(project, WorksheetPlugin.prefStore.getString(WorksheetPreferences.P_VM_ARGS))
 }

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/ProgramExecutor.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/ProgramExecutor.scala
@@ -123,13 +123,9 @@ private class ProgramExecutor private () extends DaemonActor with HasLogger {
 
           // simple configuration, main class and classpath
           val vmRunnerConfig = new VMRunnerConfiguration(mainClass, cp.toArray)
-          vmRunnerConfig.setVMArguments(Array("-Dfile.encoding="+doc.encoding.name()))
-
-          // obtain and assign VM arguments, split by whitespace
-          // empty string arguments are eliminated, since the jvm will regard one as a main class argument.
-          val vmArgs = WorksheetPlugin.plugin.getPreferenceStore().getString(WorksheetPreferences.P_VM_ARGS)
-            .split("""\s""").filterNot(_.isEmpty)
-          vmRunnerConfig.setVMArguments(vmArgs)
+          val config = Configuration(unit.scalaProject)
+          val vmArgs = config.vmArgs
+          vmRunnerConfig.setVMArguments(vmArgs.args)
 
           // a launch is need to get the created process
           val launch: ILaunch = new Launch(null, null, null)

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/SourceInstrumenter.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/SourceInstrumenter.scala
@@ -16,10 +16,10 @@ class SourceInstrumenter(config: Configuration) extends HasLogger {
    */
   case class InstrumentationResult(decl: TopLevelObjectDecl, program: Array[Char])
 
-  def instrument(unit: ScriptCompilationUnit, encoding: Charset): Either[Throwable, (TopLevelObjectDecl, File)] = {
+  def instrument(unit: ScriptCompilationUnit): Either[Throwable, (TopLevelObjectDecl, File)] = {
     instrumentProgram(unit).right map {
       case InstrumentationResult(decl, program) =>
-        (decl, writeInstrumented(decl, program, encoding))
+        (decl, writeInstrumented(decl, program))
     }
   }
 
@@ -39,9 +39,9 @@ class SourceInstrumenter(config: Configuration) extends HasLogger {
   }
 
   /** Write instrumented source file to disk. */
-  private def writeInstrumented(decl: TopLevelObjectDecl, content: Array[Char], encoding: Charset): File = {
+  private def writeInstrumented(decl: TopLevelObjectDecl, content: Array[Char]): File = {
     val sourceName = decl.fullName + ".scala"
-    val sourceFile = config.touchSource(sourceName, content, encoding)
+    val sourceFile = config.touchSource(sourceName, content, config.vmArgs.fileEncoding)
     sourceFile
   }
 }

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/VmArguments.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/VmArguments.scala
@@ -1,0 +1,43 @@
+package org.scalaide.worksheet.runtime
+
+import java.nio.charset.Charset
+import java.nio.charset.IllegalCharsetNameException
+import java.nio.charset.UnsupportedCharsetException
+import scala.tools.eclipse.logging.HasLogger
+import org.eclipse.core.resources.IProject
+import scala.Array.canBuildFrom
+
+class VmArguments(project: IProject, rawArgs: String) extends HasLogger {
+  private def projectEncoding: Charset = asCharset(project.getDefaultCharset())
+
+  private def asCharset(encoding: String): Charset = {
+    try Charset.forName(encoding)
+    catch {
+      case _: IllegalCharsetNameException | _: IllegalArgumentException | _: UnsupportedCharsetException =>
+        val defaultEncoding: Charset = Charset.forName("UTF-8")
+        eclipseLog.error("Unrecognized project's encoding '%s' in project '%s'. Using '%s'.".format(projectEncoding, project.getName, defaultEncoding))
+        defaultEncoding
+    }
+  }
+
+  // obtain and assign VM arguments, split by whitespace
+  // empty string arguments are eliminated, since the jvm will regard one as a main class argument.
+  private val cleanedArgs = rawArgs.split("""\s""").filterNot(_.isEmpty)
+
+  private val shouldUseProjectEncoding: Boolean =
+    !cleanedArgs.exists(_.matches("-Dfile.encoding=\\S"))
+
+  def args: Array[String] = {
+    if (shouldUseProjectEncoding) cleanedArgs :+ ("-Dfile.encoding=" + projectEncoding)
+    else cleanedArgs
+  }
+
+  def fileEncoding: Charset = {
+    if(shouldUseProjectEncoding) projectEncoding
+    else {
+      val encodingVmArg = cleanedArgs.find(_.matches("-Dfile.encoding=\\S")).get
+      val encodingValue = encodingVmArg.stripPrefix("-Dfile.encoding=")
+      asCharset(encodingValue)
+    }
+  }
+}

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/WorksheetRunner.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/WorksheetRunner.scala
@@ -56,7 +56,7 @@ private class WorksheetRunner private (scalaProject: ScalaProject) extends Daemo
           val stripped = SourceInserter.stripRight(editor.getContents.toCharArray())
           editor.replaceWith(stripped.mkString)
 
-          instrumenter.instrument(unit, editor.encoding) match {
+          instrumenter.instrument(unit) match {
             case Left(ex) => eclipseLog.error("Error during instrumentation of " + unit, ex)
             case Right((decl, source)) =>
               compiler.compile(source) match {


### PR DESCRIPTION
Commit SHA: 342e4bc8533495f1a1a7f8c5ee60925516a52558 allowed users to
pass specific VM arguments to the VM created to execute the worksheet.
However, that commit caused the worksheet file's encoding to be defaulted
to the system's encoding, if the "-Dfile.encoding" vm argument was not
explicitly provided by the user.

That's annoying, as the default encoding should just be the project's
encoding. And that's exactly the behavior implemented in this commit.

This commit also introduces a `VmArguments` class, which is a simple
container for manipulating VM arguments. For sure it could be much more
richer than it is now, but that is out of the scope of this commit.

Fix #138
