### PR TITLE
Transient/bump version after 0.2.0 release

### DIFF
--- a/org.scalaide.worksheet.feature/feature.xml
+++ b/org.scalaide.worksheet.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.scalaide.worksheet.feature"
       label="Scala Worksheet"
-      version="0.2.0.qualifier"
+      version="0.2.1.qualifier"
       provider-name="Scala IDE"
       plugin="org.scalaide.worksheet">
 

--- a/org.scalaide.worksheet.feature/pom.xml
+++ b/org.scalaide.worksheet.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scalaide</groupId>
     <artifactId>org.scalaide.worksheet.build</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.scalaide.worksheet.feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/org.scalaide.worksheet.runtime.library/pom.xml
+++ b/org.scalaide.worksheet.runtime.library/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scalaide</groupId>
     <artifactId>org.scalaide.worksheet.build</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.1-SNAPSHOT</version>
   </parent>
   <groupId>org.scalaide</groupId>
   <artifactId>org.scalaide.worksheet.runtime.library</artifactId>

--- a/org.scalaide.worksheet.source.feature/feature.xml
+++ b/org.scalaide.worksheet.source.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
   id="org.scalaide.worksheet.source.feature"
   label="Scala Worksheet sources"
-  version="0.2.0.qualifier"
+  version="0.2.1.qualifier"
   provider-name="Scala IDE">
 
   <description url="http://github.com/scala-ide/scala-worksheet/wiki/Getting-Started">

--- a/org.scalaide.worksheet.source.feature/pom.xml
+++ b/org.scalaide.worksheet.source.feature/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.scalaide</groupId>
     <artifactId>org.scalaide.worksheet.build</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.scalaide.worksheet.source.feature</artifactId>
   <packaging>eclipse-feature</packaging>

--- a/org.scalaide.worksheet.tests/META-INF/MANIFEST.MF
+++ b/org.scalaide.worksheet.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scala Plugin (Test)
 Bundle-SymbolicName: org.scalaide.worksheet.tests
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.1.qualifier
 Bundle-Vendor: scala-ide.org
 Fragment-Host: org.scalaide.worksheet
 Bundle-RequiredExecutionEnvironment: J2SE-1.5

--- a/org.scalaide.worksheet.tests/pom.xml
+++ b/org.scalaide.worksheet.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.scalaide</groupId>
 		<artifactId>org.scalaide.worksheet.build</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>org.scalaide.worksheet.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>

--- a/org.scalaide.worksheet.update-site/pom.xml
+++ b/org.scalaide.worksheet.update-site/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scalaide</groupId>
     <artifactId>org.scalaide.worksheet.build</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.scalaide.worksheet.update-site</artifactId>
   <packaging>eclipse-update-site</packaging>

--- a/org.scalaide.worksheet/META-INF/MANIFEST.MF
+++ b/org.scalaide.worksheet/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Scala Worksheet plugin
 Bundle-SymbolicName: org.scalaide.worksheet;singleton:=true
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.1.qualifier
 Bundle-Vendor: scala-ide.org
 Bundle-ActivationPolicy: lazy
 Bundle-Localization: plugin

--- a/org.scalaide.worksheet/pom.xml
+++ b/org.scalaide.worksheet/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.scalaide</groupId>
     <artifactId>org.scalaide.worksheet.build</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.1-SNAPSHOT</version>
   </parent>
   <artifactId>org.scalaide.worksheet</artifactId>
   <packaging>eclipse-plugin</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>org.scalaide</groupId>
   <artifactId>org.scalaide.worksheet.build</artifactId>
-  <version>0.2.0-SNAPSHOT</version>
+  <version>0.2.1-SNAPSHOT</version>
   <name>Scala Worksheet</name>
   <packaging>pom</packaging>
 


### PR DESCRIPTION
Please, don't merge this just yet. I'll do it myself if it's all good for the 0.2.0 release
