### PR TITLE
Makes eval test correctly clean up eval engine

### DIFF
--- a/org.scalaide.worksheet.tests/src/org/scalaide/worksheet/testutil/EvalTester.scala
+++ b/org.scalaide.worksheet.tests/src/org/scalaide/worksheet/testutil/EvalTester.scala
@@ -45,6 +45,15 @@ object EvalTester {
     
     WorksheetsManager.Instance ! ProgramExecutor.StopRun(unit)
     
+    // if it timed out, wait for the evaluation to be stopped
+    if (!proxy.isDone) {
+      waited = 0
+      while (waited < timeout && !proxy.isDone) {
+        Thread.sleep(timeslice)
+        waited += timeslice
+      }
+    }
+
     proxy.getContents
   }
 }


### PR DESCRIPTION
After the switch to `org.junit`, I was getting some strange timing issues when running the tests, with the timeout test (`infiniteLoop_is_cut`).
The change makes sure that the previous evaluation has been terminated before the next test can start.
