### PR TITLE
Added keyboard shortcut to clear evaluation results

### DIFF
--- a/org.scalaide.worksheet.tests/src/org/scalaide/worksheet/runtime/ClearResultsTest.scala
+++ b/org.scalaide.worksheet.tests/src/org/scalaide/worksheet/runtime/ClearResultsTest.scala
@@ -1,0 +1,85 @@
+package org.scalaide.worksheet.runtime
+
+import scala.tools.eclipse.ScalaProject
+import scala.tools.eclipse.testsetup.SDTTestUtils.createProjects
+import scala.tools.eclipse.testsetup.SDTTestUtils.deleteProjects
+import org.eclipse.core.resources.IFolder
+import org.junit.AfterClass
+import org.junit.Assert
+import org.junit.BeforeClass
+import org.junit.Test
+import org.scalaide.worksheet.WorksheetPlugin
+import org.scalaide.worksheet.properties.WorksheetPreferences
+import org.scalaide.worksheet.testutil.EvalTester.wipeResults
+import org.junit.Ignore
+
+object ClearResultsTest {
+  @BeforeClass
+  def createProject() {
+    val Seq(prj) = createProjects("clear-results-test")
+    project = prj
+
+    project.sourceOutputFolders.map {
+      case (_, outp: IFolder) => outp.create(true, true, null)
+    }
+  }
+
+  private var project: ScalaProject = _
+
+  @AfterClass
+  def deleteProject() {
+    deleteProjects(project)
+  }
+
+}
+
+class ClearResultsTest {
+
+  @Test
+  def simple_cleaning_succeeds() {
+    val initial =
+      """|object Main {
+         |  val xs = List(1, 2, 3)                          //> xs  : List[Int] = List(1, 2, 3)
+         |  xs.max                                          //> res0: Int = 3
+         |  val ys = Seq(1, 2, 3, 3,4 )                     //> ys  : Seq[Int] = List(1, 2, 3, 3, 4)
+         |}""".stripMargin
+
+    val expected =
+      """|object Main {
+         |  val xs = List(1, 2, 3)
+         |  xs.max                
+         |  val ys = Seq(1, 2, 3, 3,4 )
+         |}""".stripMargin
+
+    runTest(initial, expected)
+  }
+
+  @Test
+  def multiline_output() {
+    val initial =
+      """|object Main {
+         |  val xs = List(1, 2, 3)                          //> xs  : List[Int] = List(1, 2, 3)
+         |
+         |  xs foreach println                              //> 1
+         |                                                  //| 2
+         |                                                  //| 3
+         |}""".stripMargin
+
+    val expected =
+      """|object Main {
+         |  val xs = List(1, 2, 3)
+         |
+         |  xs foreach println                             
+         |}""".stripMargin
+
+    runTest(initial, expected)
+  }
+
+  /** Run the eval test using the initial contents and check against the given expected output.
+   */
+  def runTest(contents: String, expected: String) {
+    val res = wipeResults(contents)
+
+    Assert.assertEquals("correct output", expected.trim, res.trim)
+  }
+}

--- a/org.scalaide.worksheet.tests/src/org/scalaide/worksheet/testutil/EvalTester.scala
+++ b/org.scalaide.worksheet.tests/src/org/scalaide/worksheet/testutil/EvalTester.scala
@@ -56,4 +56,10 @@ object EvalTester {
 
     proxy.getContents
   }
+
+  def wipeResults(contents: String): String = {
+    val proxy = new EditorProxy(contents)
+    proxy.clearResults
+    proxy.getContents
+  }
 }

--- a/org.scalaide.worksheet/plugin.xml
+++ b/org.scalaide.worksheet/plugin.xml
@@ -35,12 +35,21 @@
             id="org.scalaide.worksheet.commands.format"
             name="Format">
       </command>
+      <command
+            categoryId="org.scalaide.worksheet.commands.category"
+            id="org.scalaide.worksheet.commands.clearResults"
+            name="Clear Results">
+      </command>
    </extension>
    <extension
          point="org.eclipse.ui.handlers">
       <handler
             class="org.scalaide.worksheet.handlers.EvalScript"
             commandId="org.scalaide.worksheet.commands.evalScript">
+      </handler>
+      <handler
+            class="org.scalaide.worksheet.handlers.ClearResults"
+            commandId="org.scalaide.worksheet.commands.clearResults">
       </handler>
    </extension>
    <extension
@@ -56,6 +65,12 @@
             contextId="org.scalaide.worksheet.editorScope"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
             sequence="M1+M2+F">
+      </key>
+      <key
+            commandId="org.scalaide.worksheet.commands.clearResults"
+            contextId="org.scalaide.worksheet.editorScope"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M1+M2+C">
       </key>
    </extension>
    <extension

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/DocumentHolder.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/DocumentHolder.scala
@@ -1,5 +1,8 @@
 package org.scalaide.worksheet.editor
 
+import java.nio.charset.Charset
+import org.scalaide.worksheet.text.SourceInserter
+
 /** A document holder, such as the ScriptEditor.
  * 
  *  Implementers receive asynchronous updates through `replaceWith`, therefore
@@ -28,4 +31,10 @@ trait DocumentHolder {
    *  to allow the user to interrupt the evaluation.
    */
   def endUpdate(): Unit
+
+  def clearResults(): Unit = {
+    val stripped = SourceInserter.stripRight(getContents.toCharArray)
+    replaceWith(stripped.mkString)
+  }
 }
+

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/ScriptEditor.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/ScriptEditor.scala
@@ -26,6 +26,7 @@ import org.eclipse.ui.texteditor.TextOperationAction
 import org.scalaide.worksheet.ScriptCompilationUnit
 import org.scalaide.worksheet.WorksheetPlugin
 import org.scalaide.worksheet.editor.action.RunEvaluationAction
+import org.scalaide.worksheet.editor.action.ClearResultsAction
 
 object ScriptEditor {
 
@@ -175,6 +176,11 @@ class ScriptEditor extends TextEditor with SelectionTracker with ISourceViewerEd
     formatAction.setActionDefinitionId("org.scalaide.worksheet.commands.format")
     setAction("format", formatAction)
 
+    // Adding action to clear results in the editor popup dialog
+    val clearResultsAction = new ClearResultsAction(this)
+    clearResultsAction.setActionDefinitionId("org.scalaide.worksheet.commands.clearResults")
+    setAction("clearResults", clearResultsAction)
+
     // Adding run evaluation action in the editor popup dialog
     val evalScriptAction = new RunEvaluationAction(this)
     evalScriptAction.setActionDefinitionId("org.scalaide.worksheet.commands.evalScript")
@@ -187,6 +193,7 @@ class ScriptEditor extends TextEditor with SelectionTracker with ISourceViewerEd
     // add the format menu itemevalScript    
     addAction(menu, ITextEditorActionConstants.GROUP_EDIT, "evalScript")
     addAction(menu, ITextEditorActionConstants.GROUP_EDIT, "format")
+    addAction(menu, ITextEditorActionConstants.GROUP_EDIT, "clearResults")
   }
 
   type IAnnotationModelExtended = IAnnotationModel with IAnnotationModelExtension with IAnnotationModelExtension2
@@ -220,6 +227,12 @@ class ScriptEditor extends TextEditor with SelectionTracker with ISourceViewerEd
     import org.scalaide.worksheet.runtime.WorksheetsManager
     import org.scalaide.worksheet.runtime.WorksheetRunner
     WorksheetsManager.Instance ! WorksheetRunner.RunEvaluation(_, editorProxy)
+  }
+
+  private[worksheet] def clearResults(): Unit = {
+    editorProxy.beginUpdate()
+    editorProxy.clearResults()
+    editorProxy.endUpdate()
   }
 
   private[worksheet] def stopEvaluation(): Unit = withScriptCompilationUnit {

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/action/ClearResultsAction.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/action/ClearResultsAction.scala
@@ -1,0 +1,11 @@
+package org.scalaide.worksheet.editor.action
+
+import org.eclipse.jface.action.Action
+import org.scalaide.worksheet.editor.ScriptEditor
+
+class ClearResultsAction(editor: ScriptEditor) extends Action {
+  setText("Clear Results")
+  setDescription("Clear Results in Worksheet")
+  setToolTipText("Clear Results in Worksheet")
+  override def run(): Unit = editor.clearResults()
+}

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/handlers/ClearResults.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/handlers/ClearResults.scala
@@ -1,0 +1,18 @@
+package org.scalaide.worksheet.handlers
+
+import scala.tools.eclipse.logging.HasLogger
+
+import org.eclipse.core.commands.AbstractHandler
+import org.eclipse.core.commands.ExecutionEvent
+import org.eclipse.ui.handlers.HandlerUtil
+import org.scalaide.worksheet.editor.ScriptEditor
+
+class ClearResults extends AbstractHandler with HasLogger {
+  override def execute(event: ExecutionEvent): AnyRef = {
+    HandlerUtil.getActiveEditor(event) match {
+      case editor: ScriptEditor => editor.clearResults()
+      case editor => logger.debug("Expected ScriptEditor, found "+editor)
+    }
+    null
+  }
+}

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/WorksheetRunner.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/WorksheetRunner.scala
@@ -53,8 +53,7 @@ private class WorksheetRunner private (scalaProject: ScalaProject) extends Daemo
         case RunEvaluation(unit, editor) =>
           unit.clearBuildErrors()
 
-          val stripped = SourceInserter.stripRight(editor.getContents.toCharArray())
-          editor.replaceWith(stripped.mkString)
+          editor.clearResults()
 
           instrumenter.instrument(unit) match {
             case Left(ex) => eclipseLog.error("Error during instrumentation of " + unit, ex)


### PR DESCRIPTION
(squashed version of pull #144)

New eclipse Action added.

Keyboard shortcut Ctrl+Shift+C now clears evaluation results.

Fix #132.

Also:
- Moved clearResults into DocumentHolder trait, removed DocumentHandler
