### PR TITLE
Fixes some deprecated imports

### DIFF
--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/ScriptCompilationUnit.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/ScriptCompilationUnit.scala
@@ -7,9 +7,9 @@ import scala.tools.eclipse.util.EclipseResource
 import scala.tools.eclipse.util.FileUtils
 import scala.tools.nsc.interactive.Response
 import scala.tools.nsc.io.AbstractFile
-import scala.tools.nsc.util.BatchSourceFile
-import scala.tools.nsc.util.{Position, NoPosition}
-import scala.tools.nsc.util.ScriptSourceFile
+import scala.reflect.internal.util.BatchSourceFile
+import scala.reflect.internal.util.{Position, NoPosition}
+import scala.reflect.internal.util.ScriptSourceFile
 import org.eclipse.core.resources.IFile
 import org.eclipse.core.resources.IMarker
 import org.eclipse.jdt.core.compiler.IProblem

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/completion/CompletionProposalComputer.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/completion/CompletionProposalComputer.scala
@@ -5,7 +5,7 @@ import scala.tools.eclipse.ScalaWordFinder
 import scala.tools.eclipse.completion.ScalaCompletions
 import scala.tools.eclipse.ui.ScalaCompletionProposal
 import scala.tools.eclipse.util.EditorUtils
-import scala.tools.nsc.util.SourceFile
+import scala.reflect.internal.util.SourceFile
 
 import org.eclipse.jface.text.ITextViewer
 import org.eclipse.jface.text.contentassist.ICompletionProposal

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/ResidentCompiler.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/ResidentCompiler.scala
@@ -7,7 +7,7 @@ import scala.tools.eclipse.logging.HasLogger
 import scala.tools.nsc.CompilerCommand
 import scala.tools.nsc.Settings
 import scala.tools.nsc.reporters.StoreReporter
-import scala.tools.nsc.util.Position
+import scala.reflect.internal.util.Position
 import org.scalaide.worksheet.WorksheetPlugin
 
 object ResidentCompiler extends HasLogger {

--- a/org.scalaide.worksheet/src/scala/tools/nsc/interactive/ProgramInstrumenter.scala
+++ b/org.scalaide.worksheet/src/scala/tools/nsc/interactive/ProgramInstrumenter.scala
@@ -1,6 +1,6 @@
 package scala.tools.nsc.interactive
 
-import scala.tools.nsc.util.SourceFile
+import scala.reflect.internal.util.SourceFile
 import scala.tools.eclipse.ScalaPresentationCompiler
 import scala.tools.eclipse.logging.HasLogger
 

--- a/org.scalaide.worksheet/src/scala/tools/nsc/interactive/ScratchPadMaker2.scala
+++ b/org.scalaide.worksheet/src/scala/tools/nsc/interactive/ScratchPadMaker2.scala
@@ -3,7 +3,7 @@ package interactive
 
 import scala.collection.mutable.ArrayBuffer
 import scala.tools.nsc.ast.parser.Tokens._
-import scala.tools.nsc.util.{SourceFile, BatchSourceFile, RangePosition}
+import scala.reflect.internal.util.{SourceFile, BatchSourceFile, RangePosition}
 import scala.tools.nsc.util.Chars.{isLineBreakChar, isWhitespace}
 
 // Temporarily named `ScratchPadMaker2` to avoid collision with the existing `ScratchPadMaker` in the 


### PR DESCRIPTION
Part of the compiler was moved to reflect during 2.10, with compatibility support in the old locations. Some of this compatibility support was removed a few days ago, so we need to update too.
