### PR TITLE
Update for the upcoming plugin-profiles 1.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>plugin-profiles</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.5</version>
   </parent>
 
   <groupId>org.scalaide</groupId>


### PR DESCRIPTION
Similar version bumps are expected to be added to
https://github.com/scala-ide/scala-ide-play2/pull/213
https://github.com/scala-ide/scala-search/pull/90

validation expected to fail until plugin-profiles is released.
