### PR TITLE
Adds a tiny delay in the infinite test code

### DIFF
--- a/org.scalaide.worksheet.tests/src/org/scalaide/worksheet/runtime/WorksheetEvalTest.scala
+++ b/org.scalaide.worksheet.tests/src/org/scalaide/worksheet/runtime/WorksheetEvalTest.scala
@@ -147,6 +147,7 @@ object testeval {
 
   while (true) {
     x += 1
+    Thread.sleep(10)
     println(x)
   }
 }
@@ -158,6 +159,7 @@ object testeval {
 
   while (true) {
     x += 1
+    Thread.sleep(10)
     println(x)
   }                                               //> 1
                                                   //| 2


### PR DESCRIPTION
Without it, it is possible to fill the heap, and to crash the target VM.
