### PR TITLE
Wip/migrate to akka

### DIFF
--- a/org.scalaide.worksheet.tests/.classpath
+++ b/org.scalaide.worksheet.tests/.classpath
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="lib" path="target/lib/mockito-all-1.9.0.jar"/>
+	<classpathentry kind="lib" path="target/lib/akka-testkit_2.11-2.3.9.jar" sourcepath="target/lib/akka-testkit_2.11-2.3.9-sources.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.scalaide.worksheet.tests/META-INF/MANIFEST.MF
+++ b/org.scalaide.worksheet.tests/META-INF/MANIFEST.MF
@@ -13,4 +13,5 @@ Require-Bundle: org.scala-lang.scala-library,
 Import-Package: org.aspectj.weaver.loadtime.definition,
  org.scalaide.core.testsetup
 Bundle-ClassPath: .,
- target/lib/mockito-all-1.9.0.jar
+ target/lib/mockito-all-1.9.0.jar,
+ target/lib/akka-testkit_2.11-2.3.9.jar

--- a/org.scalaide.worksheet.tests/src/org/scalaide/worksheet/runtime/WorksheetEvalTest.scala
+++ b/org.scalaide.worksheet.tests/src/org/scalaide/worksheet/runtime/WorksheetEvalTest.scala
@@ -338,7 +338,7 @@ object Snowman {
    *  The test blocks for at most `timeout` millis, but will finish as soon as the evaluator signals
    *  termination by calling 'endUpdate' on the `DocumentHolder` interface.
    */
-  def runTest(filename: String, contents: String, expected: String, timeout: Int = 30000) {
+  def runTest(filename: String, contents: String, expected: String, timeout: Int = 60000) {
     val res = runEvalSync(filename, contents, timeout)
 
     Assert.assertEquals("correct output", expected.trim, res.trim)

--- a/org.scalaide.worksheet.tests/src/org/scalaide/worksheet/testutil/EvalTester.scala
+++ b/org.scalaide.worksheet.tests/src/org/scalaide/worksheet/testutil/EvalTester.scala
@@ -2,6 +2,7 @@ package org.scalaide.worksheet.testutil
 
 import org.scalaide.worksheet.editor.DocumentHolder
 import org.scalaide.worksheet.runtime._
+import org.scalaide.worksheet.WorksheetPlugin
 
 object EvalTester {
   import WorksheetUtils._
@@ -36,14 +37,14 @@ object EvalTester {
     val unit = getUnit(name, contents)
     val proxy = new EditorProxy(contents)
 
-    WorksheetsManager.Instance ! RunEvaluation(unit, proxy)
+    WorksheetPlugin.plugin.runtime ! RunEvaluation(unit, proxy)
 
     while (waited < timeout && !proxy.isDone) {
       Thread.sleep(timeslice)
       waited += timeslice
     }
     
-    WorksheetsManager.Instance ! ProgramExecutor.StopRun(unit)
+    WorksheetPlugin.plugin.runtime ! ProgramExecutor.StopRun(unit)
     
     // if it timed out, wait for the evaluation to be stopped
     if (!proxy.isDone) {

--- a/org.scalaide.worksheet/.classpath
+++ b/org.scalaide.worksheet/.classpath
@@ -2,7 +2,9 @@
 <classpath>
 	<classpathentry kind="src" output="target/classes" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry exported="true" kind="lib" path="target/lib/akka-actor_2.11-2.3.9.jar" sourcepath="target/lib/akka-actor_2.11-2.3.9-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/akka-osgi_2.11-2.3.9.jar" sourcepath="target/lib/akka-osgi_2.11-2.3.9-sources.jar"/>
+	<classpathentry kind="lib" path="target/lib/config-1.2.1.jar" sourcepath="target/lib/config-1.2.1-sources.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.scalaide.worksheet/META-INF/MANIFEST.MF
+++ b/org.scalaide.worksheet/META-INF/MANIFEST.MF
@@ -24,7 +24,6 @@ Require-Bundle:
  org.scala-lang.scala-library;bundle-version="[2.11,2.12)",
  org.scala-lang.scala-compiler;bundle-version="[2.11,2.12)",
  org.scala-lang.scala-reflect;bundle-version="[2.11,2.12)",
- org.scala-lang.scala-actors;bundle-version="[2.11,2.12)",
  org.scala-ide.sdt.core;bundle-version="[4.0.0,5.0.0)",
  scalariform,
  org.scala-ide.sbt.full.library,
@@ -37,7 +36,10 @@ Import-Package:
  scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor.formatter;apply-aspects:=false
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Activator: org.scalaide.worksheet.WorksheetPlugin
-Bundle-ClassPath: .
+Bundle-ClassPath: .,
+ target/lib/akka-actor_2.11-2.3.9.jar,
+ target/lib/akka-osgi_2.11-2.3.9.jar,
+ target/lib/config-1.2.1.jar
 Export-Package: org.scalaide.worksheet,org.scalaide.worksheet.editor,o
  rg.scalaide.worksheet.handlers,org.scalaide.worksheet.reconciler,org.
  scalaide.worksheet.runtime

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/ScriptCompilationUnit.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/ScriptCompilationUnit.scala
@@ -1,25 +1,23 @@
 package org.scalaide.worksheet
 
-import org.scalaide.core.compiler.InteractiveCompilationUnit
-import org.scalaide.core.IScalaPlugin
-import org.scalaide.core.internal.builder.BuildProblemMarker
-import org.scalaide.core.resources.EclipseResource
-import org.scalaide.util.eclipse.FileUtils
-import scala.tools.nsc.interactive.Response
-import scala.tools.nsc.io.AbstractFile
-import scala.reflect.internal.util.BatchSourceFile
 import scala.reflect.internal.util.{Position, NoPosition}
-import scala.reflect.internal.util.ScriptSourceFile
+import scala.reflect.internal.util.BatchSourceFile
+import scala.tools.nsc.io.AbstractFile
+
 import org.eclipse.core.resources.IFile
 import org.eclipse.core.resources.IMarker
-import org.eclipse.jdt.core.compiler.IProblem
 import org.eclipse.jface.text.IDocument
 import org.eclipse.ui.IEditorInput
 import org.eclipse.ui.part.FileEditorInput
-import org.eclipse.ui.texteditor.ITextEditor
-import org.scalaide.worksheet.editor.ScriptEditor
-import org.scalaide.core.resources.MarkerFactory
+import org.scalaide.core.IScalaPlugin
 import org.scalaide.core.compiler.ISourceMap
+
+import org.scalaide.core.compiler.InteractiveCompilationUnit
+import org.scalaide.core.internal.builder.BuildProblemMarker
+import org.scalaide.core.resources.EclipseResource
+import org.scalaide.core.resources.MarkerFactory
+import org.scalaide.util.eclipse.FileUtils
+import org.scalaide.worksheet.editor.ScriptEditor
 
 /** A Script compilation unit connects the presentation compiler
  *  view of a script with the Eclipse IDE view of the underlying

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/SourceFileProvider.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/SourceFileProvider.scala
@@ -1,11 +1,11 @@
 package org.scalaide.worksheet
 
-import org.scalaide.core.compiler.InteractiveCompilationUnit
 import scala.util.control.Exception.handling
 
 import org.eclipse.core.resources.ResourcesPlugin
-
 import org.eclipse.core.runtime.IPath
+
+import org.scalaide.core.compiler.InteractiveCompilationUnit
 
 class SourceFileProvider extends org.scalaide.core.extensions.SourceFileProvider {
   override def createFrom(path: IPath): Option[InteractiveCompilationUnit] = {

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/WorksheetPlugin.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/WorksheetPlugin.scala
@@ -1,16 +1,19 @@
 package org.scalaide.worksheet
 
-import org.eclipse.ui.plugin.AbstractUIPlugin
-import org.osgi.framework.BundleContext
-import org.scalaide.util.eclipse.OSGiUtils
-import org.eclipse.core.runtime.Platform
-import org.osgi.framework.Bundle
-import org.scalaide.util.Utils.WithAsInstanceOfOpt
 import org.eclipse.core.runtime.IPath
+import org.eclipse.core.runtime.Platform
+import org.eclipse.ui.plugin.AbstractUIPlugin
+import org.osgi.framework.Bundle
+import org.osgi.framework.BundleContext
+import org.osgi.framework.BundleEvent
+import org.osgi.framework.BundleListener
 import org.scalaide.logging.HasLogger
-import org.eclipse.core.runtime.Path
-import org.scalaide.worksheet.properties.WorksheetPreferences
-import org.eclipse.core.resources.IProject
+import org.scalaide.util.eclipse.OSGiUtils
+import org.scalaide.worksheet.runtime.WorksheetsRuntime
+
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.osgi.ActorSystemActivator
 
 object WorksheetPlugin extends HasLogger {
   @volatile var plugin: WorksheetPlugin = _
@@ -25,7 +28,6 @@ object WorksheetPlugin extends HasLogger {
     path2lib
   }
 
-
   def prefStore = plugin.getPreferenceStore
 
   def getImageDescriptor(path: String) = {
@@ -35,13 +37,37 @@ object WorksheetPlugin extends HasLogger {
 
 class WorksheetPlugin extends AbstractUIPlugin {
 
+  @volatile private var bundleListener: BundleListener = _
+  @volatile var runtime: ActorRef = _
+  
+  class WorksheetActorSystemActivator extends ActorSystemActivator {
+    override def configure(context: BundleContext, system: ActorSystem): Unit = {
+      runtime = system.actorOf(WorksheetsRuntime.props, WorksheetsRuntime.ActorName)
+    }
+  }
+
+  private val system = new WorksheetActorSystemActivator
+
   override def start(context: BundleContext) = {
     super.start(context)
+    bundleListener = new BundleListener() {
+      override def bundleChanged(event: BundleEvent) {
+        if (event.getBundle() == getBundle()) {
+          if (event.getType() == BundleEvent.STARTED)
+            system.start(context)
+        }
+      }
+    }
+    context.addBundleListener(bundleListener)
+
     WorksheetPlugin.plugin = this
   }
 
   override def stop(context: BundleContext) = {
     WorksheetPlugin.plugin = null
+    system.stop(context)
+    if (bundleListener != null)
+      context.removeBundleListener(bundleListener)
     super.stop(context)
   }
 }

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/completion/CompletionProposalComputer.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/completion/CompletionProposalComputer.scala
@@ -1,17 +1,14 @@
 package org.scalaide.worksheet.completion
 
-import org.scalaide.core.compiler.IScalaPresentationCompiler
-import org.scalaide.util.ScalaWordFinder
-import org.scalaide.core.completion.ScalaCompletions
-import org.scalaide.ui.completion.ScalaCompletionProposal
-import org.scalaide.util.eclipse.EditorUtils
-import scala.reflect.internal.util.SourceFile
-
 import org.eclipse.jface.text.ITextViewer
 import org.eclipse.jface.text.contentassist.ICompletionProposal
 import org.eclipse.jface.text.contentassist.IContentAssistProcessor
 import org.eclipse.jface.text.contentassist.IContextInformation
 import org.eclipse.ui.texteditor.ITextEditor
+import org.scalaide.core.completion.ScalaCompletions
+import org.scalaide.ui.completion.ScalaCompletionProposal
+import org.scalaide.util.ScalaWordFinder
+import org.scalaide.util.eclipse.EditorUtils
 import org.scalaide.worksheet.ScriptCompilationUnit
 
 class CompletionProposalComputer(textEditor: ITextEditor) extends ScalaCompletions with IContentAssistProcessor {

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/DocumentHolder.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/DocumentHolder.scala
@@ -1,6 +1,5 @@
 package org.scalaide.worksheet.editor
 
-import java.nio.charset.Charset
 import org.scalaide.worksheet.text.SourceInserter
 
 /** A document holder, such as the ScriptEditor.

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/EvaluationResultsAutoEditStrategy.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/EvaluationResultsAutoEditStrategy.scala
@@ -3,13 +3,10 @@ package org.scalaide.worksheet.editor
 import scala.collection.mutable.StringBuilder
 
 import org.eclipse.jface.text.DocumentCommand
-
 import org.eclipse.jface.text.IAutoEditStrategy
 import org.eclipse.jface.text.IDocument
-import org.eclipse.jface.text.TextUtilities
 import org.eclipse.jface.text.IRegion
-import scala.collection.mutable.StringBuilder
-import scala.annotation.tailrec
+import org.eclipse.jface.text.TextUtilities
 
 object EvaluationResultsAutoEditStrategy {
 }
@@ -137,7 +134,6 @@ private[editor] object DocumentCommandUpdater {
         line.length()
     }
   }
-
 }
 
 private[editor] class DocumentCommandUpdater(

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/ScriptConfiguration.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/ScriptConfiguration.scala
@@ -1,43 +1,36 @@
 package org.scalaide.worksheet.editor
 
-import org.scalaide.core.IScalaPlugin
-import org.scalaide.core.internal.formatter.ScalaFormattingStrategy
-import org.scalaide.ui.syntax.ScalaSyntaxClasses
-import org.scalaide.ui.internal.editor.autoedits.BracketAutoEditStrategy
-import org.eclipse.jdt.internal.ui.JavaPlugin
 import org.eclipse.jdt.ui.text.IJavaPartitions
 import org.eclipse.jface.preference.IPreferenceStore
 import org.eclipse.jface.text.DefaultIndentLineAutoEditStrategy
-import org.eclipse.jface.text.DefaultTextHover
 import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.ITextHover
 import org.eclipse.jface.text.contentassist.ContentAssistant
 import org.eclipse.jface.text.contentassist.IContentAssistant
 import org.eclipse.jface.text.formatter.MultiPassContentFormatter
 import org.eclipse.jface.text.hyperlink.IHyperlinkDetector
+import org.eclipse.jface.text.information.InformationPresenter
 import org.eclipse.jface.text.presentation.PresentationReconciler
 import org.eclipse.jface.text.reconciler.IReconciler
 import org.eclipse.jface.text.reconciler.MonoReconciler
 import org.eclipse.jface.text.rules.DefaultDamagerRepairer
-import org.eclipse.jface.text.rules.ITokenScanner
 import org.eclipse.jface.text.source.Annotation
 import org.eclipse.jface.text.source.DefaultAnnotationHover
 import org.eclipse.jface.text.source.IAnnotationHover
 import org.eclipse.jface.text.source.ISourceViewer
 import org.eclipse.jface.text.source.SourceViewerConfiguration
-import org.eclipse.jface.util.PropertyChangeEvent
-import org.eclipse.ui.texteditor.ITextEditor
-import org.scalaide.worksheet.completion.CompletionProposalComputer
-import org.scalaide.worksheet.lexical.SingleLineCommentScanner
-import org.scalaide.worksheet.reconciler.ScalaReconcilingStrategy
-import scalariform.ScalaVersions
-import org.scalaide.worksheet.ScriptCompilationUnit
 import org.eclipse.jface.util.IPropertyChangeListener
+import org.eclipse.jface.util.PropertyChangeEvent
+
+import org.scalaide.core.IScalaPlugin
+import org.scalaide.core.internal.formatter.ScalaFormattingStrategy
 import org.scalaide.core.lexical.ScalaCodeScanners
 import org.scalaide.core.lexical.ScalaPartitions
-import org.scalaide.ui.editor.hover.IScalaHover
-import org.eclipse.jface.text.information.InformationPresenter
 import org.scalaide.ui.editor.SourceConfiguration
+import org.scalaide.ui.editor.hover.IScalaHover
+import org.scalaide.ui.internal.editor.autoedits.BracketAutoEditStrategy
+import org.scalaide.worksheet.completion.CompletionProposalComputer
+import org.scalaide.worksheet.reconciler.ScalaReconcilingStrategy
 
 class ScriptConfiguration(val pluginPreferenceStore: IPreferenceStore, javaPreferenceStore: IPreferenceStore, textEditor: ScriptEditor) extends SourceViewerConfiguration with IPropertyChangeListener {
   @inline private def scalaPreferenceStore: IPreferenceStore = IScalaPlugin().getPreferenceStore()

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/ScriptDocumentProvider.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/ScriptDocumentProvider.scala
@@ -1,12 +1,12 @@
 package org.scalaide.worksheet.editor
 
+import org.eclipse.core.filebuffers.IDocumentSetupParticipant
+
 import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.IDocumentExtension3
-import org.eclipse.ui.editors.text.FileDocumentProvider
-import org.eclipse.ui.editors.text.TextFileDocumentProvider
 import org.eclipse.ui.editors.text.ForwardingDocumentProvider
+import org.eclipse.ui.editors.text.TextFileDocumentProvider
 import org.eclipse.ui.texteditor.IDocumentProvider
-import org.eclipse.core.filebuffers.IDocumentSetupParticipant
 import org.scalaide.core.lexical.ScalaCodePartitioner
 
 /** A Document provider for Scala scripts. It sets the Scala

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/ScriptEditor.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/editor/ScriptEditor.scala
@@ -1,11 +1,10 @@
 package org.scalaide.worksheet.editor
 
-import org.scalaide.ui.editor.ISourceViewerEditor
-import org.scalaide.ui.editor.InteractiveCompilationUnitEditor
-import org.scalaide.core.compiler.InteractiveCompilationUnit
-import org.scalaide.logging.HasLogger
 import org.eclipse.jdt.core.compiler.IProblem
 import org.eclipse.jdt.internal.ui.javaeditor.CompilationUnitDocumentProvider.ProblemAnnotation
+import org.eclipse.jdt.ui.PreferenceConstants
+import org.eclipse.jdt.ui.actions.IJavaEditorActionDefinitionIds
+import org.eclipse.jface.action.Action
 import org.eclipse.jface.action.IMenuManager
 import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.ITextSelection
@@ -22,17 +21,18 @@ import org.eclipse.swt.events.KeyEvent
 import org.eclipse.ui.editors.text.TextEditor
 import org.eclipse.ui.texteditor.ITextEditorActionConstants
 import org.eclipse.ui.texteditor.TextOperationAction
+import org.scalaide.core.compiler.InteractiveCompilationUnit
+import org.scalaide.logging.HasLogger
+
+import org.scalaide.ui.editor.ISourceViewerEditor
+import org.scalaide.ui.editor.InteractiveCompilationUnitEditor
+import org.scalaide.ui.editor.SourceConfiguration
+import org.scalaide.util.eclipse.EditorUtils
+import org.scalaide.util.ui.DisplayThread
 import org.scalaide.worksheet.ScriptCompilationUnit
 import org.scalaide.worksheet.WorksheetPlugin
-import org.scalaide.worksheet.editor.action.RunEvaluationAction
 import org.scalaide.worksheet.editor.action.ClearResultsAction
-import org.scalaide.util.ui.DisplayThread
-import org.eclipse.jdt.ui.PreferenceConstants
-import org.eclipse.jface.action.Action
-import org.scalaide.util.eclipse.EditorUtils
-import org.eclipse.jdt.ui.actions.IJavaEditorActionDefinitionIds
-import org.eclipse.ui.editors.text.TextFileDocumentProvider
-import org.scalaide.ui.editor.SourceConfiguration
+import org.scalaide.worksheet.editor.action.RunEvaluationAction
 
 object ScriptEditor {
 
@@ -50,6 +50,8 @@ class ScriptEditor extends TextEditor with SelectionTracker with ISourceViewerEd
   private def prefStore = WorksheetPlugin.prefStore
 
   private lazy val sourceViewConfiguration = new ScriptConfiguration(prefStore, PreferenceConstants.getPreferenceStore, this)
+
+  // constructor
   setSourceViewerConfiguration(sourceViewConfiguration)
   //  setPreferenceStore(prefStore)
   setPartName("Scala Script Editor")
@@ -248,9 +250,8 @@ class ScriptEditor extends TextEditor with SelectionTracker with ISourceViewerEd
   private[worksheet] def runEvaluation(): Unit = withScriptCompilationUnit {
     editorProxy.beginUpdate()
 
-    import org.scalaide.worksheet.runtime.WorksheetsManager
     import org.scalaide.worksheet.runtime.WorksheetRunner
-    WorksheetsManager.Instance ! WorksheetRunner.RunEvaluation(_, editorProxy)
+    WorksheetPlugin.plugin.runtime ! WorksheetRunner.RunEvaluation(_, editorProxy)
   }
 
   private[worksheet] def clearResults(): Unit = {
@@ -262,9 +263,8 @@ class ScriptEditor extends TextEditor with SelectionTracker with ISourceViewerEd
   private[worksheet] def stopEvaluation(): Unit = withScriptCompilationUnit {
     editorProxy.stopExternalEditorUpdate()
 
-    import org.scalaide.worksheet.runtime.WorksheetsManager
     import org.scalaide.worksheet.runtime.ProgramExecutor
-    WorksheetsManager.Instance ! ProgramExecutor.StopRun(_)
+    WorksheetPlugin.plugin.runtime ! ProgramExecutor.StopRun(_)
   }
 
   private def withScriptCompilationUnit(f: ScriptCompilationUnit => Unit): Unit = f(ScriptCompilationUnit.fromEditor(this))

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/handlers/ClearResults.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/handlers/ClearResults.scala
@@ -1,10 +1,10 @@
 package org.scalaide.worksheet.handlers
 
-import org.scalaide.logging.HasLogger
-
 import org.eclipse.core.commands.AbstractHandler
 import org.eclipse.core.commands.ExecutionEvent
 import org.eclipse.ui.handlers.HandlerUtil
+
+import org.scalaide.logging.HasLogger
 import org.scalaide.worksheet.editor.ScriptEditor
 
 class ClearResults extends AbstractHandler with HasLogger {

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/handlers/EvalScript.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/handlers/EvalScript.scala
@@ -1,10 +1,10 @@
 package org.scalaide.worksheet.handlers
 
-import org.scalaide.logging.HasLogger
-
 import org.eclipse.core.commands.AbstractHandler
 import org.eclipse.core.commands.ExecutionEvent
 import org.eclipse.ui.handlers.HandlerUtil
+
+import org.scalaide.logging.HasLogger
 import org.scalaide.worksheet.editor.ScriptEditor
 
 class EvalScript extends AbstractHandler with HasLogger {

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/lexical/SingleLineCommentScanner.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/lexical/SingleLineCommentScanner.scala
@@ -1,15 +1,14 @@
 package org.scalaide.worksheet.lexical
 
-import org.scalaide.ui.syntax.ScalaSyntaxClass
-import org.scalaide.ui.syntax.ScalaSyntaxClasses
-
 import org.eclipse.jface.preference.IPreferenceStore
 import org.eclipse.jface.text.IDocument
 import org.eclipse.jface.text.rules.IToken
 import org.eclipse.jface.text.rules.ITokenScanner
 import org.eclipse.jface.text.rules.Token
 import org.eclipse.jface.util.PropertyChangeEvent
-import org.scalaide.worksheet.lexical.SyntaxClasses
+
+import org.scalaide.ui.syntax.ScalaSyntaxClass
+import org.scalaide.ui.syntax.ScalaSyntaxClasses
 
 class SingleLineCommentScanner(val scalaPreferenceStore: IPreferenceStore, val worksheetPreferenceStore: IPreferenceStore) extends ITokenScanner {
   import SingleLineCommentScanner._

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/properties/ColorPreferenceInitializer.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/properties/ColorPreferenceInitializer.scala
@@ -1,11 +1,11 @@
 package org.scalaide.worksheet.properties
 
-import org.scalaide.ui.syntax.ScalaSyntaxClass
-
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer
 import org.eclipse.jface.preference.IPreferenceStore
 import org.eclipse.jface.resource.StringConverter
 import org.eclipse.swt.graphics.RGB
+
+import org.scalaide.ui.syntax.ScalaSyntaxClass
 import org.scalaide.worksheet.WorksheetPlugin
 import org.scalaide.worksheet.lexical.SyntaxClasses
 

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/properties/WorksheetPreferenceInitializer.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/properties/WorksheetPreferenceInitializer.scala
@@ -1,7 +1,8 @@
 package org.scalaide.worksheet.properties
 
-import org.scalaide.worksheet.WorksheetPlugin
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer
+
+import org.scalaide.worksheet.WorksheetPlugin
 
 class WorksheetPreferenceInitializer extends AbstractPreferenceInitializer {
 

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/reconciler/ScalaReconcilingStrategy.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/reconciler/ScalaReconcilingStrategy.scala
@@ -6,10 +6,10 @@ import org.eclipse.jface.text.IDocumentListener
 import org.eclipse.jface.text.IRegion
 import org.eclipse.jface.text.reconciler.DirtyRegion
 import org.eclipse.jface.text.reconciler.IReconcilingStrategy
+import org.eclipse.jface.text.reconciler.IReconcilingStrategyExtension
 import org.scalaide.logging.HasLogger
 import org.scalaide.worksheet.ScriptCompilationUnit
 import org.scalaide.worksheet.editor.ScriptEditor
-import org.eclipse.jface.text.reconciler.IReconcilingStrategyExtension
 
 class ScalaReconcilingStrategy(textEditor: ScriptEditor) extends IReconcilingStrategy with IReconcilingStrategyExtension with HasLogger {
   private var document: IDocument = _

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/Configuration.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/Configuration.scala
@@ -5,11 +5,10 @@ import java.io.FileOutputStream
 import java.io.OutputStreamWriter
 import java.nio.charset.Charset
 
-import org.scalaide.core.IScalaProject
-
 import org.eclipse.core.resources.IProject
 import org.eclipse.core.runtime.IPath
 import org.eclipse.core.runtime.Path
+import org.scalaide.core.IScalaProject
 import org.scalaide.worksheet.WorksheetPlugin
 import org.scalaide.worksheet.properties.WorksheetPreferences
 

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/ResidentCompiler.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/ResidentCompiler.scala
@@ -1,13 +1,14 @@
 package org.scalaide.worksheet.runtime
 
 import java.io.File
-import org.scalaide.core.IScalaPlugin
-import org.scalaide.core.IScalaProject
-import org.scalaide.logging.HasLogger
+
+import scala.reflect.internal.util.Position
 import scala.tools.nsc.CompilerCommand
 import scala.tools.nsc.Settings
 import scala.tools.nsc.reporters.StoreReporter
-import scala.reflect.internal.util.Position
+
+import org.scalaide.core.IScalaProject
+import org.scalaide.logging.HasLogger
 import org.scalaide.worksheet.WorksheetPlugin
 
 object ResidentCompiler extends HasLogger {

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/SourceInstrumenter.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/SourceInstrumenter.scala
@@ -1,13 +1,15 @@
 package org.scalaide.worksheet.runtime
 
 import java.io.File
+
 import scala.Left
 import scala.Right
 import scala.tools.nsc.interactive.ProgramInstrumenter
+
+import org.scalaide.core.compiler.IScalaPresentationCompiler
 import org.scalaide.logging.HasLogger
 import org.scalaide.worksheet.ScriptCompilationUnit
 import org.scalaide.worksheet.text.SourceInserter
-import org.scalaide.core.compiler.IScalaPresentationCompiler
 
 case class TopLevelObjectDecl(fullName: String)
 

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/VmArguments.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/VmArguments.scala
@@ -3,9 +3,9 @@ package org.scalaide.worksheet.runtime
 import java.nio.charset.Charset
 import java.nio.charset.IllegalCharsetNameException
 import java.nio.charset.UnsupportedCharsetException
-import org.scalaide.logging.HasLogger
+
 import org.eclipse.core.resources.IProject
-import scala.Array.canBuildFrom
+import org.scalaide.logging.HasLogger
 
 class VmArguments(project: IProject, rawArgs: String) extends HasLogger {
   private def projectEncoding: Charset = asCharset(project.getDefaultCharset())

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/WorksheetRunner.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/WorksheetRunner.scala
@@ -1,103 +1,103 @@
 package org.scalaide.worksheet.runtime
 
-import scala.actors.{ Actor, DaemonActor }
-import org.scalaide.logging.HasLogger
-import org.scalaide.worksheet.ScriptCompilationUnit
-import org.scalaide.worksheet.editor.DocumentHolder
-import org.scalaide.worksheet.text.SourceInserter
-import org.scalaide.core.IScalaProject
-import org.scalaide.core.IScalaProjectEvent
-import org.scalaide.core.BuildSuccess
-import org.scalaide.worksheet.WorksheetPlugin
-import org.scalaide.util.ui.DisplayThread
 import scala.collection.mutable.Publisher
 import scala.collection.mutable.Subscriber
 
+import org.scalaide.core.BuildSuccess
+import org.scalaide.core.IScalaProject
+import org.scalaide.core.IScalaProjectEvent
+import org.scalaide.logging.HasLogger
+import org.scalaide.util.ui.DisplayThread
+import org.scalaide.worksheet.ScriptCompilationUnit
+import org.scalaide.worksheet.WorksheetPlugin
+import org.scalaide.worksheet.editor.DocumentHolder
+
+import akka.actor.Actor
+import akka.actor.ActorRef
+import akka.actor.Props
+
 object WorksheetRunner {
 
-  private[runtime] def apply(scalaProject: IScalaProject): Actor = {
-    val worksheet = new WorksheetRunner(scalaProject)
-    worksheet.start()
-    worksheet
-  }
+  private[runtime] def props(scalaProject: IScalaProject): Props =
+    Props(new WorksheetRunner(scalaProject))
 
   case class RunEvaluation(unit: ScriptCompilationUnit, editor: DocumentHolder)
   case object RefreshResidentCompiler
+
+  class BuildListener(worksheetRunner: ActorRef) extends Subscriber[IScalaProjectEvent, Publisher[IScalaProjectEvent]] {
+    override def notify(pub: Publisher[IScalaProjectEvent], event: IScalaProjectEvent) = {
+      event match {
+        case e: BuildSuccess => worksheetRunner ! RefreshResidentCompiler
+      }
+    }
+  }
 }
 
 /** An evaluator for worksheet documents.
- *
- *  It evaluates the contents of the given document and returns the output of the
- *  instrumented program.
- *
- *  It instantiates the instrumented program in-process, using a different class-loader.
- *  A more advanced evaluator would spawn a new VM, to allow debugging in the future.
- */
-private class WorksheetRunner private (scalaProject: IScalaProject) extends DaemonActor with Subscriber[IScalaProjectEvent, Publisher[IScalaProjectEvent]] with HasLogger {
+  *
+  * It evaluates the contents of the given document and returns the output of the
+  * instrumented program.
+  *
+  * It instantiates the instrumented program in-process, using a different class-loader.
+  * A more advanced evaluator would spawn a new VM, to allow debugging in the future.
+  */
+private class WorksheetRunner private (scalaProject: IScalaProject) extends Actor with HasLogger {
   import WorksheetRunner._
   import ResidentCompiler._
 
   private val config = Configuration(scalaProject)
   private val instrumenter = new SourceInstrumenter(config)
   private var compiler = ResidentCompiler(scalaProject, config)
-  private val executor = ProgramExecutor()
+  private var executor: ActorRef = _
+  private var buildListener: BuildListener = _
 
-
-  override def notify(pub: Publisher[IScalaProjectEvent], event:IScalaProjectEvent) = {
-    event match {
-      case e: BuildSuccess => WorksheetRunner.this ! RefreshResidentCompiler
-    }
+  override def preStart(): Unit = {
+    buildListener = new BuildListener(self)
+    scalaProject.subscribe(buildListener)
+    executor = context.actorOf(ProgramExecutor.props())
   }
 
-  scalaProject.subscribe(this)
+  override def postStop(): Unit = {
+    scalaProject.removeSubscription(buildListener)
+  }
 
-  override def act() = {
-    loop {
-      react {
-        case RunEvaluation(unit, editor) =>
-          unit.clearBuildErrors()
+  override def receive = {
+    case RunEvaluation(unit, editor) =>
+      unit.clearBuildErrors()
 
-          editor.clearResults()
+      editor.clearResults()
 
-          instrumenter.instrument(unit) match {
-            case Left(ex) => eclipseLog.error("Error during instrumentation of " + unit, ex)
-            case Right((decl, source)) =>
-              compiler.compile(source) match {
-                case CompilationFailed(errors) =>
-                  logger.debug("compilation errors in " + (unit.file.name) + ": " + errors.mkString(","))
-                  editor.endUpdate()
-                  // Fix the race condition in error markers by updating them
-                  // on the UI thread. Otherwise, the 'replaceWith' call before
-                  // might remove all markers, considering their positions 'deleted'
-                  // by the replace action
-                  DisplayThread.asyncExec { reportBuildErrors(unit, errors) }
+      instrumenter.instrument(unit) match {
+        case Left(ex) => eclipseLog.error("Error during instrumentation of " + unit, ex)
+        case Right((decl, source)) =>
+          compiler.compile(source) match {
+            case CompilationFailed(errors) =>
+              logger.debug("compilation errors in " + (unit.file.name) + ": " + errors.mkString(","))
+              editor.endUpdate()
+              // Fix the race condition in error markers by updating them
+              // on the UI thread. Otherwise, the 'replaceWith' call before
+              // might remove all markers, considering their positions 'deleted'
+              // by the replace action
+              DisplayThread.asyncExec { reportBuildErrors(unit, errors) }
 
-                case CompilationSuccess =>
-                  executor ! ProgramExecutor.RunProgram(unit, decl.fullName, classpath, editor)
-              }
+            case CompilationSuccess =>
+              executor ! ProgramExecutor.RunProgram(unit, decl.fullName, classpath, editor)
           }
-
-        case msg: ProgramExecutor.StopRun =>
-          logger.info("forwarding " + msg + " to " + executor)
-          executor forward msg
-
-        case RefreshResidentCompiler =>
-          logger.info("Refreshing worksheet resident compiler for " + scalaProject)
-          compiler = ResidentCompiler(scalaProject, config)
-
-        case any =>
-          scalaProject.removeSubscription(this)
-          exit("Unsupported message " + any)
       }
-    }
+
+    case msg: ProgramExecutor.StopRun =>
+      executor forward msg
+
+    case RefreshResidentCompiler =>
+      compiler = ResidentCompiler(scalaProject, config)
   }
 
   /** The classpath, as a list of local filesystem path
-   */
+    */
   private def classpath: Seq[String] = {
     WorksheetPlugin.worksheetLibrary.map(_.toOSString()).toSeq ++
-    scalaProject.scalaClasspath.fullClasspath.map(_.getAbsolutePath()) ++
-    scalaProject.outputFolderLocations.map(_.toOSString()) :+ config.binFolder.getAbsolutePath()
+      scalaProject.scalaClasspath.fullClasspath.map(_.getAbsolutePath()) ++
+      scalaProject.outputFolderLocations.map(_.toOSString()) :+ config.binFolder.getAbsolutePath()
   }
 
   private def reportBuildErrors(unit: ScriptCompilationUnit, errors: Iterable[CompilationError]): Unit = {

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/WorksheetsRuntime.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/WorksheetsRuntime.scala
@@ -1,0 +1,30 @@
+package org.scalaide.worksheet.runtime
+
+import akka.actor.Actor
+import akka.actor.OneForOneStrategy
+import akka.actor.SupervisorStrategy._
+import akka.actor.Props
+import akka.actor.ActorRef
+
+object WorksheetsRuntime {
+  final val ActorName = "worksheet-runtime"
+
+  def props(): Props = Props(new WorksheetsRuntime)
+}
+
+private class WorksheetsRuntime private() extends Actor {
+
+  override val supervisorStrategy = OneForOneStrategy() {
+    case e: Exception => Resume
+  }
+
+  var worksheetsManager: ActorRef = _
+  
+  override def preStart(): Unit = {
+    worksheetsManager = context.actorOf(WorksheetsManager.props(), WorksheetsManager.ActorName)
+  }
+
+  override def receive() = {
+    case msg => worksheetsManager forward msg
+  }
+}

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/text/Mixer.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/text/Mixer.scala
@@ -1,10 +1,10 @@
 package org.scalaide.worksheet.text
 
 import java.io.{ FileInputStream, InputStreamReader, IOException }
-import scala.runtime.ScalaRunTime.stringOf
-import java.lang.reflect.InvocationTargetException
-import collection.mutable.ArrayBuffer
+
+import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable.ListBuffer
+
 import org.scalaide.logging.HasLogger
 
 class Mixer extends HasLogger {

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/text/SourceInserter.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/text/SourceInserter.scala
@@ -2,8 +2,6 @@ package org.scalaide.worksheet.text
 
 import java.io.Writer
 
-//import reflect.internal.Chars._
-
 object SourceInserter {
   val LineBreak = System.getProperty("line.separator")
   def stripRight(cs: Array[Char]): Array[Char] = {

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/wizards/NewWorksheetWizard.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/wizards/NewWorksheetWizard.scala
@@ -1,6 +1,5 @@
 package org.scalaide.worksheet.wizards
 
-import org.scalaide.logging.HasLogger
 import org.eclipse.jface.viewers.IStructuredSelection
 import org.eclipse.jface.wizard.Wizard
 import org.eclipse.ui.INewWizard
@@ -8,8 +7,10 @@ import org.eclipse.ui.IWorkbench
 import org.eclipse.ui.PartInitException
 import org.eclipse.ui.PlatformUI
 import org.eclipse.ui.ide.IDE
-import org.scalaide.worksheet.editor.ScriptEditor
+
+import org.scalaide.logging.HasLogger
 import org.scalaide.util.ui.DisplayThread
+import org.scalaide.worksheet.editor.ScriptEditor
 
 /**
  * A wizard to create a new Scala worksheet file.

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/wizards/NewWorksheetWizardPage.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/wizards/NewWorksheetWizardPage.scala
@@ -2,13 +2,14 @@ package org.scalaide.worksheet.wizards
 
 import java.io.ByteArrayInputStream
 import java.io.InputStream
+
+import org.eclipse.core.resources.ResourcesPlugin
+import org.eclipse.core.runtime.IPath
 import org.eclipse.core.runtime.IStatus
 import org.eclipse.core.runtime.Status
 import org.eclipse.jface.viewers.IStructuredSelection
 import org.eclipse.swt.widgets.Composite
 import org.eclipse.ui.dialogs.WizardNewFileCreationPage
-import org.eclipse.core.runtime.IPath
-import org.eclipse.core.resources.ResourcesPlugin
 import org.scalaide.core.IScalaPlugin
 
 /** Wizard page based of the new file creation page from the framework.

--- a/org.scalaide.worksheet/src/scala/tools/nsc/interactive/ScratchPadMaker2.scala
+++ b/org.scalaide.worksheet/src/scala/tools/nsc/interactive/ScratchPadMaker2.scala
@@ -2,8 +2,8 @@ package scala.tools.nsc
 package interactive
 
 import scala.collection.mutable.ArrayBuffer
+import scala.reflect.internal.util.{SourceFile, RangePosition}
 import scala.tools.nsc.ast.parser.Tokens._
-import scala.reflect.internal.util.{SourceFile, BatchSourceFile, RangePosition}
 import scala.tools.nsc.util.Chars.{isLineBreakChar, isWhitespace}
 
 // Temporarily named `ScratchPadMaker2` to avoid collision with the existing `ScratchPadMaker` in the 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,8 @@
   <properties>
     <tycho.test.encoding>-Dfile.encoding=UTF-8</tycho.test.encoding>
     <tycho.test.jvmArgs>-Xmx800m -XX:MaxPermSize=256m -Dsdtcore.headless ${tycho.test.encoding} ${tycho.test.weaving} ${tycho.test.OSspecific}</tycho.test.jvmArgs>
+    <akka.version>2.3.9</akka.version>
+    <config.version>1.2.1</config.version>
   </properties>
 
   <modules>
@@ -32,4 +34,87 @@
     <module>org.scalaide.worksheet.update-site</module>
   </modules>
 
+  <dependencies>
+    <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+      <version>${config.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe.akka</groupId>
+      <artifactId>akka-actor_${scala.version.short}</artifactId>
+      <version>${akka.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe.akka</groupId>
+      <artifactId>akka-osgi_${scala.version.short}</artifactId>
+      <version>${akka.version}</version>
+    </dependency>
+    <!-- test support -->
+    <dependency>
+      <groupId>com.typesafe.akka</groupId>
+      <artifactId>akka-testkit_${scala.version.short}</artifactId>
+      <version>${akka.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <!-- copy the jar dependencies -->
+          <execution>
+            <id>src-dependencies</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>com.typesafe</groupId>
+                  <artifactId>config</artifactId>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.typesafe.akka</groupId>
+                  <artifactId>akka-actor_${scala.version.short}</artifactId>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.typesafe.akka</groupId>
+                  <artifactId>akka-actor_${scala.version.short}</artifactId>
+                  <classifier>sources</classifier>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.typesafe.akka</groupId>
+                  <artifactId>akka-osgi_${scala.version.short}</artifactId>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.typesafe</groupId>
+                  <artifactId>config</artifactId>
+                  <classifier>sources</classifier>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.typesafe.akka</groupId>
+                  <artifactId>akka-osgi_${scala.version.short}</artifactId>
+                  <classifier>sources</classifier>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.typesafe.akka</groupId>
+                  <artifactId>akka-testkit_${scala.version.short}</artifactId>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>com.typesafe.akka</groupId>
+                  <artifactId>akka-testkit_${scala.version.short}</artifactId>
+                  <classifier>sources</classifier>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Migrated the codebase to use akka-actor, instead of the old and deprecated scala-actors lib.

Before merging, I'd like to squash all commits but the [last one](https://github.com/dotta/scala-worksheet/commit/0066b0f1becb958bb73b7572f51986ccb245530d) (let me know if you disagree). 