### PR TITLE
Fixed memory leak in `WorksheetsManager`

### DIFF
--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/WorksheetRunner.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/WorksheetRunner.scala
@@ -51,6 +51,8 @@ private class WorksheetRunner private (scalaProject: IScalaProject) extends Acto
   private var executor: ActorRef = _
   private var buildListener: BuildListener = _
 
+  private val projectName  = scalaProject.underlying.getName
+
   override def preStart(): Unit = {
     buildListener = new BuildListener(self)
     scalaProject.subscribe(buildListener)
@@ -59,6 +61,7 @@ private class WorksheetRunner private (scalaProject: IScalaProject) extends Acto
 
   override def postStop(): Unit = {
     scalaProject.removeSubscription(buildListener)
+    logger.debug(s"Shutted down worksheet runner for project `$projectName`.")
   }
 
   override def receive = {
@@ -104,5 +107,5 @@ private class WorksheetRunner private (scalaProject: IScalaProject) extends Acto
     errors map { error => unit.reportBuildError(error.msg, error.pos) }
   }
 
-  override def toString: String = "WorksheetEvaluator <actor>"
+  override def toString: String = "WorksheetRunner <actor>"
 }

--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/WorksheetsManager.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/WorksheetsManager.scala
@@ -1,35 +1,78 @@
 package org.scalaide.worksheet.runtime
 
-import scala.collection.immutable
+import scala.collection.concurrent
+import scala.ref.WeakReference
 import scala.util.Try
 
+import org.eclipse.core.resources.IResourceChangeEvent
+import org.eclipse.core.resources.IResourceChangeListener
+import org.eclipse.core.resources.ResourcesPlugin
 import org.eclipse.core.runtime.IPath
 import org.scalaide.logging.HasLogger
 import org.scalaide.worksheet.ScriptCompilationUnit
 
 import akka.actor.Actor
 import akka.actor.ActorRef
+import akka.actor.ActorSystem
 import akka.actor.Props
 
 object WorksheetsManager {
   final val ActorName = "worksheet-manager"
   def props(): Props = Props(new WorksheetsManager)
+
+  private object ProjectChangeListener {
+    def apply(system: ActorSystem, worksheetRunners: concurrent.Map[IPath, ActorRef]): IResourceChangeListener =
+      new ProjectChangeListener(WeakReference(system), WeakReference(worksheetRunners))
+
+    private class ProjectChangeListener(system: WeakReference[ActorSystem], worksheetRunners: WeakReference[concurrent.Map[IPath, ActorRef]]) extends IResourceChangeListener {
+      import IResourceChangeEvent._
+      def resourceChanged(event: IResourceChangeEvent): Unit = {
+        def resource = event.getResource()
+        event.getType match {
+          case PRE_CLOSE  => removeWorksheetRunnerFor(resource.getFullPath)
+          case PRE_DELETE => removeWorksheetRunnerFor(resource.getFullPath)
+        }
+      }
+
+      private def removeWorksheetRunnerFor(fullpath: IPath): Unit = {
+        for {
+          worksheetRunners <- worksheetRunners.get
+          worksheetRunner <- worksheetRunners.remove(fullpath)
+        } system.get.foreach(_.stop(worksheetRunner))
+      }
+    }
+  }
 }
 
 private class WorksheetsManager private extends Actor with HasLogger {
+  import WorksheetsManager.ProjectChangeListener
   import WorksheetRunner.RunEvaluation
   import ProgramExecutor.StopRun
 
-  //FIXME: Need to dispose worksheet evaluator and remove it from the map when the project is disposed
-  private var worksheets: immutable.Map[IPath, ActorRef] = immutable.HashMap.empty
+  private val worksheets: concurrent.Map[IPath, ActorRef] = concurrent.TrieMap.empty
+  private var projectListener: IResourceChangeListener = _
+
+  override def preStart(): Unit = {
+    projectListener = ProjectChangeListener(context.system, worksheets)
+    workspace.addResourceChangeListener(projectListener, IResourceChangeEvent.PRE_CLOSE | IResourceChangeEvent.PRE_DELETE)
+    super.preStart()
+  }
+
+  override def postStop(): Unit = {
+    workspace.removeResourceChangeListener(projectListener)
+    projectListener = null
+    super.postStop()
+  }
+
+  private def workspace = ResourcesPlugin.getWorkspace()
 
   override def receive = {
-      case msg @ RunEvaluation(unit, _) =>
-        obtainEvaluator(unit) forward msg
+    case msg @ RunEvaluation(unit, _) =>
+      obtainEvaluator(unit) forward msg
 
-      case msg: StopRun =>
-        forwardIfEvaluatorExists(msg)
-    }
+    case msg: StopRun =>
+      forwardIfEvaluatorExists(msg)
+  }
 
   private def forwardIfEvaluatorExists(msg: StopRun): Unit = {
     // if the project is closed, `unit.scalaProject` throws NoSuchElementException
@@ -45,8 +88,7 @@ private class WorksheetsManager private extends Actor with HasLogger {
     worksheets.get(scalaProject.underlying.getFullPath) match {
       case Some(evaluator) => evaluator
       case None =>
-        val evaluator = context.actorOf(WorksheetRunner.props(scalaProject), "worksheet-runner-for-project-"+scalaProject.underlying.getName)
-
+        val evaluator = context.actorOf(WorksheetRunner.props(scalaProject), "worksheet-runner-for-project-" + scalaProject.underlying.getName)
         worksheets += (scalaProject.underlying.getFullPath -> evaluator)
         evaluator
     }


### PR DESCRIPTION
When closing/deleting a project, the actor used to execute the worksheet was
both not stopped and removed from the `WorksheetsManager` map. This commit
fixes both issues.