### PR TITLE
Fixes problem with non-existing syntetic file

### DIFF
--- a/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/SourceInstrumenter.scala
+++ b/org.scalaide.worksheet/src/org/scalaide/worksheet/runtime/SourceInstrumenter.scala
@@ -46,6 +46,7 @@ class SourceInstrumenter(config: Configuration) extends HasLogger {
   /** Write instrumented source file to disk. */
   private def writeInstrumented(decl: TopLevelObjectDecl, content: Array[Char]): File = {
     val sourceName = decl.fullName + ".scala"
+    logger.info(s"writing $sourceName with content ${content.take(20).mkString}")
     val sourceFile = config.touchSource(sourceName, content, config.vmArgs.fileEncoding)
     sourceFile
   }


### PR DESCRIPTION
When .sc file is compiled such exception is thrown in certain
condition (not fully determined)
```
2017-11-23 19:21:30,121 ERROR [bundle-358-ActorSystem-akka.actor.default-dispatcher-32] - ResidentCompiler - ## Exception when compiling 1 sources to [/media/wpopielarski/0bdab96b-2e8f-4cd1-82ac-212f16fd303a/tools/eclipses/eclipse-4.7.1-rc1/ws/kielce/.worksheet/bin]
Resource '/kielce/.worksheet/src/kielce.functor2.scala' does not exist.
org.eclipse.core.internal.resources.Resource.checkExists(Resource.java:335)
org.eclipse.core.internal.resources.Resource.checkAccessible(Resource.java:209)
org.eclipse.core.internal.resources.Resource.createMarker(Resource.java:696)
org.scalaide.core.resources.MarkerFactory.create(MarkerFactory.scala:48)
org.scalaide.core.internal.builder.zinc.SbtBuildReporter.$anonfun$createMarker$4(SbtBuildReporter.scala:111)
org.scalaide.core.internal.builder.zinc.SbtBuildReporter.$anonfun$createMarker$4$adapted(SbtBuildReporter.scala:108)
scala.Option.map(Option.scala:146)
org.scalaide.core.internal.builder.zinc.SbtBuildReporter.$anonfun$createMarker$3(SbtBuildReporter.scala:108)
scala.Option.flatMap(Option.scala:171)
org.scalaide.core.internal.builder.zinc.SbtBuildReporter.$anonfun$createMarker$2(SbtBuildReporter.scala:107)
scala.Option.flatMap(Option.scala:171)
org.scalaide.core.internal.builder.zinc.SbtBuildReporter.$anonfun$createMarker$1(SbtBuildReporter.scala:106)
scala.Option.flatMap(Option.scala:171)
org.scalaide.core.internal.builder.zinc.SbtBuildReporter.createMarker(SbtBuildReporter.scala:105)
org.scalaide.core.internal.builder.zinc.SbtBuildReporter.log(SbtBuildReporter.scala:83)
xsbt.DelegatingReporter.info0(DelegatingReporter.scala:125)
xsbt.DelegatingReporter.info0(DelegatingReporter.scala:102)
scala.reflect.internal.Reporter.error(Reporting.scala:84)
scala.tools.nsc.typechecker.Contexts$ImmediateReporter.handleError(Contexts.scala:1380)
scala.tools.nsc.typechecker.Contexts$ContextReporter.issue(Contexts.scala:1257)
scala.tools.nsc.typechecker.Contexts$Context.issue(Contexts.scala:579)
scala.tools.nsc.typechecker.ContextErrors$ErrorUtils$.issueTypeError(ContextErrors.scala:106)
scala.tools.nsc.typechecker.ContextErrors$ErrorUtils$.issueNormalTypeError(ContextErrors.scala:99)
scala.tools.nsc.typechecker.ContextErrors$TyperContextErrors$TyperErrorGen$.NotAMemberError(ContextErrors.scala:377)
scala.tools.nsc.typechecker.Typers$Typer.$anonfun$typed1$1(Typers.scala:4210)
scala.tools.nsc.typechecker.Typers$Typer.lookupInQualifier$1(Typers.scala:4209)
scala.tools.nsc.typechecker.Typers$Typer.$anonfun$typed1$56(Typers.scala:4942)
scala.tools.nsc.typechecker.Typers$Typer.handleMissing$1(Typers.scala:4942)
scala.tools.nsc.typechecker.Typers$Typer.typedSelectInternal$1(Typers.scala:4947)
scala.tools.nsc.typechecker.Typers$Typer.typedSelect$1(Typers.scala:4867)
scala.tools.nsc.typechecker.Typers$Typer.typedSelectOrSuperCall$1(Typers.scala:5006)
scala.tools.nsc.typechecker.Typers$Typer.typedInAnyMode$1(Typers.scala:5537)
scala.tools.nsc.typechecker.Typers$Typer.typed1(Typers.scala:5553)
scala.tools.nsc.typechecker.Typers$Typer.runTyper$1(Typers.scala:5589)
scala.tools.nsc.typechecker.Typers$Typer.typedInternal(Typers.scala:5619)
scala.tools.nsc.typechecker.Typers$Typer.body$2(Typers.scala:5563)
scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5567)
scala.tools.nsc.typechecker.Typers$Typer.typedQualifier(Typers.scala:5670)
scala.tools.nsc.typechecker.Typers$Typer.typedQualifier(Typers.scala:5678)
scala.tools.nsc.typechecker.Namers$Namer.scala$tools$nsc$typechecker$Namers$Namer$$importSig(Namers.scala:1689)
scala.tools.nsc.typechecker.Namers$Namer$ImportTypeCompleter.completeImpl(Namers.scala:872)
scala.tools.nsc.typechecker.Namers$LockingTypeCompleter.complete(Namers.scala:1948)
scala.tools.nsc.typechecker.Namers$LockingTypeCompleter.complete$(Namers.scala:1946)
scala.tools.nsc.typechecker.Namers$TypeCompleterBase.complete(Namers.scala:1941)
scala.reflect.internal.Symbols$Symbol.info(Symbols.scala:1531)
scala.reflect.internal.Symbols$Symbol.initialize(Symbols.scala:1679)
scala.tools.nsc.typechecker.Typers$Typer.typedStat$1(Typers.scala:3063)
scala.tools.nsc.typechecker.Typers$Typer.$anonfun$typedStats$10(Typers.scala:3220)
scala.tools.nsc.typechecker.Typers$Typer.typedStats(Typers.scala:3220)
scala.tools.nsc.typechecker.Typers$Typer.typedTemplate(Typers.scala:1983)
scala.tools.nsc.typechecker.Typers$Typer.typedModuleDef(Typers.scala:1854)
scala.tools.nsc.typechecker.Typers$Typer.typedMemberDef$1(Typers.scala:5503)
scala.tools.nsc.typechecker.Typers$Typer.typed1(Typers.scala:5552)
scala.tools.nsc.typechecker.Typers$Typer.runTyper$1(Typers.scala:5589)
scala.tools.nsc.typechecker.Typers$Typer.typedInternal(Typers.scala:5619)
scala.tools.nsc.typechecker.Typers$Typer.body$2(Typers.scala:5563)
scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5567)
scala.tools.nsc.typechecker.Typers$Typer.typedByValueExpr(Typers.scala:5650)
scala.tools.nsc.typechecker.Typers$Typer.typedStat$1(Typers.scala:3075)
scala.tools.nsc.typechecker.Typers$Typer.$anonfun$typedStats$10(Typers.scala:3220)
scala.tools.nsc.typechecker.Typers$Typer.typedStats(Typers.scala:3220)
scala.tools.nsc.typechecker.Typers$Typer.typedPackageDef$1(Typers.scala:5202)
scala.tools.nsc.typechecker.Typers$Typer.typedMemberDef$1(Typers.scala:5505)
scala.tools.nsc.typechecker.Typers$Typer.typed1(Typers.scala:5552)
scala.tools.nsc.typechecker.Typers$Typer.runTyper$1(Typers.scala:5589)
scala.tools.nsc.typechecker.Typers$Typer.typedInternal(Typers.scala:5619)
scala.tools.nsc.typechecker.Typers$Typer.body$2(Typers.scala:5563)
scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5567)
scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5646)
scala.tools.nsc.typechecker.Analyzer$typerFactory$$anon$3.apply(Analyzer.scala:102)
scala.tools.nsc.Global$GlobalPhase.$anonfun$applyPhase$1(Global.scala:426)
scala.tools.nsc.Global$GlobalPhase.applyPhase(Global.scala:419)
scala.tools.nsc.typechecker.Analyzer$typerFactory$$anon$3.$anonfun$run$1(Analyzer.scala:94)
scala.tools.nsc.typechecker.Analyzer$typerFactory$$anon$3.$anonfun$run$1$adapted(Analyzer.scala:93)
scala.collection.Iterator.foreach(Iterator.scala:929)
scala.collection.Iterator.foreach$(Iterator.scala:929)
scala.collection.AbstractIterator.foreach(Iterator.scala:1417)
scala.tools.nsc.typechecker.Analyzer$typerFactory$$anon$3.run(Analyzer.scala:93)
scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1431)
scala.tools.nsc.Global$Run.compileUnits(Global.scala:1416)
scala.tools.nsc.Global$Run.compileSources(Global.scala:1412)
scala.tools.nsc.Global$Run.compile(Global.scala:1515)
xsbt.CachedCompiler0.run(CompilerInterface.scala:131)
xsbt.CachedCompiler0.run(CompilerInterface.scala:106)
xsbt.CompilerInterface.run(CompilerInterface.scala:32)
sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
java.lang.reflect.Method.invoke(Method.java:498)
sbt.internal.inc.AnalyzingCompiler.call(AnalyzingCompiler.scala:237)
sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:111)
sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:90)
sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$3(MixedAnalyzingCompiler.scala:81)
scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
sbt.internal.inc.MixedAnalyzingCompiler.timed(MixedAnalyzingCompiler.scala:132)
sbt.internal.inc.MixedAnalyzingCompiler.compileScala$1(MixedAnalyzingCompiler.scala:72)
sbt.internal.inc.MixedAnalyzingCompiler.compile(MixedAnalyzingCompiler.scala:115)
sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1(IncrementalCompilerImpl.scala:305)
sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1$adapted(IncrementalCompilerImpl.scala:305)
sbt.internal.inc.Incremental$.doCompile(Incremental.scala:101)
sbt.internal.inc.Incremental$.$anonfun$compile$4(Incremental.scala:82)
sbt.internal.inc.IncrementalCommon.recompileClasses(IncrementalCommon.scala:118)
sbt.internal.inc.IncrementalCommon.cycle(IncrementalCommon.scala:64)
sbt.internal.inc.Incremental$.$anonfun$compile$3(Incremental.scala:84)
sbt.internal.inc.Incremental$.manageClassfiles(Incremental.scala:129)
sbt.internal.inc.Incremental$.compile(Incremental.scala:75)
sbt.internal.inc.IncrementalCompile$.apply(Compile.scala:70)
sbt.internal.inc.IncrementalCompilerImpl.compileInternal(IncrementalCompilerImpl.scala:309)
sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileIncrementally$1(IncrementalCompilerImpl.scala:267)
sbt.internal.inc.IncrementalCompilerImpl.handleCompilationError(IncrementalCompilerImpl.scala:158)
sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally(IncrementalCompilerImpl.scala:237)
sbt.internal.inc.IncrementalCompilerImpl.compile(IncrementalCompilerImpl.scala:145)
org.scalaide.core.internal.builder.zinc.ResidentCompiler.compile(ResidentCompiler.scala:63)
org.scalaide.worksheet.runtime.WorksheetRunner$$anonfun$receive$1.applyOrElse(WorksheetRunner.scala:88)
akka.actor.Actor.aroundReceive(Actor.scala:497)
akka.actor.Actor.aroundReceive$(Actor.scala:495)
org.scalaide.worksheet.runtime.WorksheetRunner.aroundReceive(WorksheetRunner.scala:48)
akka.actor.ActorCell.receiveMessage(ActorCell.scala:526)
akka.actor.ActorCell.invoke(ActorCell.scala:495)
akka.dispatch.Mailbox.processMailbox(Mailbox.scala:257)
akka.dispatch.Mailbox.run(Mailbox.scala:224)
akka.dispatch.Mailbox.exec(Mailbox.scala:234)
java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
```

This fix optimizes file creation aligned to Java 8 and removes
File Removal. File Removal is unnecessary operation because
everytime .sc is updated the new content is written to its .scala
counterpart.